### PR TITLE
Fix full-color (24-bit) devices rendered as grayscale

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 github: bnussbau
 buy_me_a_coffee: bnussbau
-custom: ["https://usetrmnl.com/?ref=laravel-trmnl"]
+custom: ["https://trmnl.com/?ref=laravel-trmnl"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.5.0
+        uses: dependabot/fetch-metadata@v3.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.0.0
+        uses: dependabot/fetch-metadata@v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -23,6 +23,6 @@ jobs:
         uses: aglipanci/laravel-pint-action@2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_message: Fix styling

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -23,6 +23,6 @@ jobs:
         uses: aglipanci/laravel-pint-action@2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Fix styling

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.4]
+        os: [ubuntu-latest]
+        php: [8.4, 8.3]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
@@ -35,7 +35,13 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
+          coverage: xdebug
+
+      - name: Disable AppArmor
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
+      - name: Install Puppeteer
+        run: npm install puppeteer
 
       - name: Setup problem matchers
         run: |
@@ -49,4 +55,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --ci --coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3]
+        php: [8.5, 8.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -25,7 +25,7 @@ jobs:
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: main
           commit_message: Update CHANGELOG

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -25,7 +25,7 @@ jobs:
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v6
         with:
           branch: main
           commit_message: Update CHANGELOG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
 ### What's Changed
 
-* test: add mock for easier testing by @bnussbau in https://github.com/bnussbau/trmnl-pipeline-php/pull/3
+* test: add TrmnlPipeline::fake() for easier testing by @bnussbau in https://github.com/bnussbau/trmnl-pipeline-php/pull/3
   * https://github.com/bnussbau/trmnl-pipeline-php?tab=readme-ov-file#testing-with-fake-mode
   
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,6 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.1.0 - 2025-09-17
+
+Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.6.0 - 2025-12-02
+
+### What's Changed
+
+* feat: add timezone option to BrowserStage
+
+**Full Changelog**: https://github.com/bnussbau/trmnl-pipeline-php/compare/0.5.0...0.6.0
+
 ## 0.5.0 - 2025-11-25
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.3.1 - 2025-10-14
+
+### What's Changed
+
+* fix(#1): apply colormap to 2-bit images to prevent them from appearing too dark
+
+**Full Changelog**: https://github.com/bnussbau/trmnl-pipeline-php/compare/0.3.0...0.3.1
+
 ## 0.3.0 - 2025-09-24
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.3.2 - 2025-10-17
+
+### What's Changed
+
+* fix: Browsershot::html() creates new instance, use setHtml() instead
+
+**Full Changelog**: https://github.com/bnussbau/trmnl-pipeline-php/compare/0.3.1...0.3.2
+
 ## 0.3.1 - 2025-10-14
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.3.3 - 2025-10-29
+
+### What's Changed
+
+* fix: 1-bit and 2-bit image remapping / dithering
+
+**Full Changelog**: https://github.com/bnussbau/trmnl-pipeline-php/compare/0.3.2...0.3.3
+
 ## 0.3.2 - 2025-10-17
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.2.0 - 2025-09-18
+
+### What's Changed
+
+* feat: enable FloydSteinberg dithering in quantize step
+
+**Full Changelog**: https://github.com/bnussbau/trmnl-pipeline-php/compare/0.1.0...0.2.0
+
 ## 0.1.0 - 2025-09-17
 
 Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.4.0 - 2025-10-30
+
+### What's Changed
+
+* feat: add property 'dither()' to ImageStage to control dithering
+
+**Full Changelog**: https://github.com/bnussbau/trmnl-pipeline-php/compare/0.3.3...0.4.0
+
 ## 0.3.3 - 2025-10-29
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.8.0 - 2026-02-12
+
+### What's Changed
+
+* feat: add URL support to BrowserStage for rendering web pages
+
+**Full Changelog**: https://github.com/bnussbau/trmnl-pipeline-php/compare/0.7.0...0.8.0
+
 ## 0.7.0 - 2026-02-07
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.7.0 - 2026-02-07
+
+### What's Changed
+
+* feat: enhance color palette support and update model configurations
+
+**Full Changelog**: https://github.com/bnussbau/trmnl-pipeline-php/compare/0.6.0...0.7.0
+
 ## 0.6.0 - 2025-12-02
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Changelog
 
-All notable changes to `trmnl-render-php` will be documented in this file.
+All notable changes to `trmnl-pipeline-php` will be documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.3.0 - 2025-09-24
+
+### What's Changed
+
+* test: add mock for easier testing by @bnussbau in https://github.com/bnussbau/trmnl-pipeline-php/pull/3
+  * https://github.com/bnussbau/trmnl-pipeline-php?tab=readme-ov-file#testing-with-fake-mode
+  
+
+**Full Changelog**: https://github.com/bnussbau/trmnl-pipeline-php/compare/0.2.0...0.3.0
+
 ## 0.2.0 - 2025-09-18
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.5.0 - 2025-11-25
+
+### What's Changed
+
+* feat(#7): add color palette support by @bnussbau in https://github.com/bnussbau/trmnl-pipeline-php/pull/9
+* feat: add models
+  * TRMNL X
+  * Amazon Kindle Scribe
+  * Seeed E1001 Monochrome
+  * Seeed E1002 (2-bit)
+  * Waveshare 4.26 (2-bit)
+  * Waveshare 7.5 B/W
+  
+
+**Full Changelog**: https://github.com/bnussbau/trmnl-pipeline-php/compare/0.4.0...0.5.0
+
 ## 0.4.0 - 2025-10-30
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
 ### What's Changed
 
-* test: add TrmnlPipeline::fake() for easier testing by @bnussbau in https://github.com/bnussbau/trmnl-pipeline-php/pull/3
+* test: add EpaperPipeline::fake() for easier testing by @bnussbau in https://github.com/bnussbau/trmnl-pipeline-php/pull/3
   * https://github.com/bnussbau/trmnl-pipeline-php?tab=readme-ov-file#testing-with-fake-mode
   
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 1.0.0 - 2026-05-12
+
+### What's Changed
+
+* BREAKING CHANGE: updated name to `epaper-pipeline-php` and updated namespace to `Bnussbau\EpaperPipeline`
+  
+* feat: update models, palettes (via api)
+  
+  * AMAZON_KINDLE_PAPERWHITE_SIGNATURE_11TH_GEN
+  * AMAZON_KINDLE_VOYAGE
+  * AVALUE_EPD_42S
+  * ED133UT2
+  * GENERIC_16_9
+  * INKPLATE_5_2
+  * INKPLATE_6_PLUS
+  * KOBO_AURA_H2O_2
+  * KOBO_FORMA
+  * KOBO_GLO
+  * KOBO_SAGE
+  * KOBO_TOUCH
+  * NOOK_SIMPLE_TOUCH
+  * ONXY_BOOX_NOVA_AIR_C
+  * ONYX_BOOX_GO_7
+  * OPENFRAME
+  * PALMA
+  * RASPBERRY_PI_TOUCH_2
+  * TRMNL_OG_BWRY
+  * WAVESHARE_7_5_BWR
+  * WAVESHARE_7_5_BWRY
+  * XTEINK_X4
+  
+* chore: renamed enum cases in Model
+  
+  * OG_PNG -> TRMNL_OG
+  * OG_PLUS -> TRMNL_OG_2BIT
+  * V2 -> TRMNL_X
+  * legacy values are kept
+  
+
+**Full Changelog**: https://github.com/bnussbau/epaper-pipeline-php/compare/0.8.0...1.0.0
+
 ## 0.9.0 - 2026-05-11
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to `trmnl-pipeline-php` will be documented in this file.
 
+## 0.9.0 - 2026-05-11
+
+### What's Changed
+
+* feat: update models, palettes (via api)
+  
+  * AMAZON_KINDLE_PAPERWHITE_SIGNATURE_11TH_GEN
+  * AMAZON_KINDLE_VOYAGE
+  * AVALUE_EPD_42S
+  * ED133UT2
+  * GENERIC_16_9
+  * INKPLATE_5_2
+  * INKPLATE_6_PLUS
+  * KOBO_AURA_H2O_2
+  * KOBO_FORMA
+  * KOBO_GLO
+  * KOBO_SAGE
+  * KOBO_TOUCH
+  * NOOK_SIMPLE_TOUCH
+  * ONXY_BOOX_NOVA_AIR_C
+  * ONYX_BOOX_GO_7
+  * OPENFRAME
+  * PALMA
+  * RASPBERRY_PI_TOUCH_2
+  * TRMNL_OG_BWRY
+  * WAVESHARE_7_5_BWR
+  * WAVESHARE_7_5_BWRY
+  * XTEINK_X4
+  
+* chore: renamed enum cases in Model
+  
+  * OG_PNG -> TRMNL_OG
+  * OG_PLUS -> TRMNL_OG_2BIT
+  * V2 -> TRMNL_X
+  * legacy values are kept
+  
+
+**Full Changelog**: https://github.com/bnussbau/epaper-pipeline-php/compare/0.8.0...0.9.0
+
 ## 0.8.0 - 2026-02-12
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TRMNL Pipeline PHP
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/bnussbau/trmnl-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
+[![License](https://img.shields.io/badge/License%20-MIT-blue?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 [![Tests](https://img.shields.io/github/actions/workflow/status/bnussbau/trmnl-pipeline-php/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/bnussbau/trmnl-pipeline-php/actions/workflows/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/bnussbau/trmnl-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Command line wrapper for this package: [trmnl-pipeline-cmd](https://github.com/b
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.2 or higher (PHP 8.4 + 8.5 are tested in CI)
 - Imagick extension
 - Spatie Browsershot (requires Node.js and Puppeteer -> see [Browsershot Requirements](https://spatie.be/docs/browsershot/v4/requirements))
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@
 [![Tests](https://img.shields.io/github/actions/workflow/status/bnussbau/trmnl-pipeline-php/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/bnussbau/trmnl-pipeline-php/actions/workflows/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/bnussbau/trmnl-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 
+TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content into optimized images for a wide range of e-ink devices. The image processing pipeline includes grayscale conversion, color quantization, and device-specific optimizations.
+
+<img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/e84fc752-552e-4cb9-a1c0-aa2596176db7" />
+
+
 ## Features
 
 - **Browser Rendering**: HTML to image conversion using Spatie Browsershot
 - **Image Processing**: Advanced image manipulation using ImageMagick
-- **TRMNL Models API**: Automatic support for >=12 different e-ink device models
-- **Pipeline Pattern**: Uses the League Pipeline package for clean, composable image processing
+- **TRMNL Models API**: Automatic support for >=12 different e-ink device models.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,35 @@ $image = new TrmnlPipeline()
 echo "Generated image: $image";
 ```
 
+### Browser Rendering on AWS Lambda
+
+You can use different Browsershot implementations (like BrowsershotLambda) by passing an instance to the BrowserStage.
+See installation instructions and requirments for [stefanzweifel/sidecar-browsershot](https://github.com/stefanzweifel/sidecar-browsershot).
+
+```php
+use Bnussbau\TrmnlPipeline\Model;
+use Bnussbau\TrmnlPipeline\TrmnlPipeline;
+use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
+use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+use Wnx\SidecarBrowsershot\BrowsershotLambda;
+
+$html = file_get_contents('./tests/assets/framework2_og.html');
+
+// Create your custom Browsershot instance (e.g., BrowsershotLambda)
+$browsershotLambda = new BrowsershotLambda();
+
+$image = new TrmnlPipeline()
+    ->model(Model::OG)
+    ->pipe(new BrowserStage($browsershotLambda)
+        ->html($html))
+    ->pipe(new ImageStage())
+    ->process();
+
+echo "Generated image: $image";
+```
+
+This allows you to use BrowsershotLambda or any other Browsershot implementation that extends `Spatie\Browsershot\Browsershot`.
+
 ## API Reference
 
 ### Pipeline
@@ -116,6 +145,7 @@ $browserStage
     ->html('<html><body>Content</body></html>')
     ->width(800)
     ->height(480)
+    ->useDefaultDimensions() // force 800x480 e.g. in combination with Model to upscale image
     ->setBrowsershotOption('addStyleTag', json_encode(['content' => 'body{ color: red; }']));
 
 $result = $browserStage(null);

--- a/README.md
+++ b/README.md
@@ -188,7 +188,10 @@ $result = $pipeline->process($payload); // Process payload
 
 ### BrowserStage
 
-Converts HTML to PNG images using Spatie Browsershot.
+Converts HTML or a URL to PNG images using Spatie Browsershot. You must provide content via either `html()` or `url()` (mutually exclusive).
+
+- **`html(string $html)`** — Set HTML content to render (e.g. a template or string).
+- **`url(string $url)`** — Set a URL to capture (e.g. `https://example.com`). Use this when you want to screenshot a live webpage instead of rendering HTML. If the page is not black-and-white or contains photos, combine with **`->dither()`** on `ImageStage` so the image is converted cleanly to the model’s limited palette; otherwise gradients and images can look harsh or banded.
 
 ```php
 $browserStage = new BrowserStage();
@@ -200,6 +203,16 @@ $browserStage
     ->setBrowsershotOption('addStyleTag', json_encode(['content' => 'body{ color: red; }']));
 
 $result = $browserStage(null);
+```
+
+Screenshot from URL with dithering (recommended for full-color or image-heavy pages):
+
+```php
+$image = (new TrmnlPipeline())
+    ->model(Model::OG)
+    ->pipe((new BrowserStage())->url('https://example.com'))
+    ->pipe((new ImageStage())->dither())
+    ->process();
 ```
 
 ### ImageStage

--- a/README.md
+++ b/README.md
@@ -214,6 +214,56 @@ use Bnussbau\TrmnlPipeline\Stages\ImageStage;
     ->bitDepth(1);
 ```
 
+#### Color Support
+
+The pipeline supports color images via palettes defined in `palettes.json`. Models can specify one or more palette IDs, and the first palette with a `colors` array will be automatically applied. Color palettes use RGB colorspace for quantization and support dithering.
+
+**Example 1: Using Model Preset with Color Palette**
+
+```php
+use Bnussbau\TrmnlPipeline\Model;
+use Bnussbau\TrmnlPipeline\TrmnlPipeline;
+use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
+use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+
+$html = file_get_contents('./tests/assets/color_6a_test.html');
+
+// Inky Impression 13.3 model has color-6a palette (6 colors: red, green, blue, yellow, black, white)
+$image = new TrmnlPipeline()
+    ->model(Model::INKY_IMPRESSION_13_3)
+    ->pipe(new BrowserStage()
+        ->html($html))
+    ->pipe(new ImageStage())
+    ->process();
+
+echo "Generated color image: $image";
+```
+
+**Example 2: Defining Color Palette as Array**
+
+```php
+use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+
+// Define custom color palette (6 colors)
+$colorPalette = [
+    '#FF0000', // Red
+    '#00FF00', // Green
+    '#0000FF', // Blue
+    '#FFFF00', // Yellow
+    '#000000', // Black
+    '#FFFFFF', // White
+];
+
+$imageStage = new ImageStage();
+$imageStage
+    ->format('png')
+    ->colormap($colorPalette)
+    ->dither(true); // Dithering works with color palettes (optional; only use for images)
+
+$result = $imageStage('/path/to/input.png');
+echo "Processed color image: $result";
+```
+
 ### Model
 
 Access device model configurations.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://img.shields.io/github/actions/workflow/status/bnussbau/trmnl-pipeline-php/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/bnussbau/trmnl-pipeline-php/actions/workflows/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/bnussbau/trmnl-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 
-TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-ink devices supported by the [TRMNL Models API](https://usetrmnl.com/api/models). The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations.
+TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-ink devices supported by the [TRMNL Models API](https://usetrmnl.com/api/models). The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations. This package is used in [usetrmnl/byos_laravel](https://github.com/usetrmnl/byos_laravel).
 
 <img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/e84fc752-552e-4cb9-a1c0-aa2596176db7" />
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ $imageStage
 $result = $imageStage('/path/to/input.png');
 ```
 
+#### Dithering
+
+Recommended for photos but not for images containing mostly text, where it can make edges and letters appear rough or unclear. Dithering converts a grayscale photo into only black and white pixels by using patterns or noise to simulate intermediate shades, creating the illusion of continuous tones through spatial averaging.
+
+```php
+use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+
+(new ImageStage())
+    ->dither()
+    ->colors(2)
+    ->bitDepth(1);
+```
+
 ### Model
 
 Access device model configurations.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,33 @@ echo "Generated image: $image";
 
 This allows you to use BrowsershotLambda or any other Browsershot implementation that extends `Spatie\Browsershot\Browsershot`.
 
+### Testing with Fake Mode
+
+You can use the `fake()` method to prevent actual Browsershot and Imagick operations:
+
+```php
+use Bnussbau\TrmnlPipeline\Model;
+use Bnussbau\TrmnlPipeline\TrmnlPipeline;
+use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
+use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+
+// Enable fake mode for testing
+TrmnlPipeline::fake();
+
+$html = '<html><body>Test Content</body></html>';
+
+$result = (new TrmnlPipeline())
+    ->model(Model::OG)
+    ->pipe(new BrowserStage()->html($html))
+    ->pipe(new ImageStage())
+    ->process();
+
+echo "Mock image generated: $result";
+
+// Disable fake mode when done
+TrmnlPipeline::restore();
+```
+
 ## API Reference
 
 ### Pipeline

--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ $image = new TrmnlPipeline()
 echo "Generated image: $image";
 ```
 
+### Setting the Browser Timezone (optional)
+
+You can control the timezone used by the headless browser when rendering your HTML by calling `timezone()` on `BrowserStage` with any valid PHP timezone identifier (e.g., `UTC`, `America/New_York`, `Europe/Berlin`).
+
+Notes:
+- The timezone is only applied when you explicitly call `timezone()`. If you don’t explicitly set the timezone, the browser will use the system timezone.
+- This can be helpful when your HTML or scripts render time/date-dependent content.
+
+Example:
+
+```php
+use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
+
+$image = (new \Bnussbau\TrmnlPipeline\TrmnlPipeline())
+    ->pipe((new BrowserStage())
+        ->timezone('America/New_York')
+        ->html('<html><body><script>document.write(new Date().toString())</script></body></html>'))
+    ->pipe(new \Bnussbau\TrmnlPipeline\Stages\ImageStage())
+    ->process();
+```
+
 ### Browser Rendering on AWS Lambda
 
 You can use different Browsershot implementations (like BrowsershotLambda) by passing an instance to the BrowserStage.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Tests](https://img.shields.io/github/actions/workflow/status/bnussbau/trmnl-pipeline-php/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/bnussbau/trmnl-pipeline-php/actions/workflows/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/bnussbau/trmnl-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 
-TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content into optimized images for a wide range of e-ink devices. The image processing pipeline includes grayscale conversion, color quantization, and device-specific optimizations.
+TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-ink devices supported by the [TRMNL Models API](https://usetrmnl.com/api/models). The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations.
 
 <img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/e84fc752-552e-4cb9-a1c0-aa2596176db7" />
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://img.shields.io/github/actions/workflow/status/bnussbau/trmnl-pipeline-php/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/bnussbau/trmnl-pipeline-php/actions/workflows/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/bnussbau/trmnl-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 
-TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-ink devices supported by the [TRMNL Models API](https://usetrmnl.com/api/models). The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations. This package is used in [usetrmnl/byos_laravel](https://github.com/usetrmnl/byos_laravel).
+TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-ink devices supported by the [TRMNL Models API](https://trmnl.com/api/models). The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations. This package is used in [usetrmnl/byos_laravel](https://github.com/usetrmnl/byos_laravel).
 
 Command line wrapper for this package: [trmnl-pipeline-cmd](https://github.com/bnussbau/trmnl-pipeline-cmd)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-ink devices supported by the [TRMNL Models API](https://usetrmnl.com/api/models). The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations. This package is used in [usetrmnl/byos_laravel](https://github.com/usetrmnl/byos_laravel).
 
+Command line wrapper for this package: [trmnl-pipeline-cmd](https://github.com/bnussbau/trmnl-pipeline-cmd)
+
 <img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/e84fc752-552e-4cb9-a1c0-aa2596176db7" />
 
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ $image = new TrmnlPipeline()
         ->format('png')
         ->width(800)
         ->height(600)
+        ->rotation(90)
         ->colors(256)
-        ->bitDepth(8)
-        ->rotation(90))
+        ->bitDepth(8))
     ->process();
 
 echo "Generated image: $image";
@@ -131,9 +131,11 @@ $imageStage
     ->format('png')
     ->width(800)
     ->height(480)
+    ->offsetX(0)
+    ->offsetY(0)
+    ->rotation(0)
     ->colors(2)
     ->bitDepth(1)
-    ->rotation(0)
     ->outputPath('/path/to/output.png');
 
 $result = $imageStage('/path/to/input.png');

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Command line wrapper for this package: [epaper-pipeline-cmd](https://github.com/
 
 - **Browser Rendering**: HTML to image conversion using Spatie Browsershot
 - **Image Processing**: Advanced image manipulation using ImageMagick
-- **TRMNL Models API**: Automatic support for >=12 different e-paper device models.
+- **TRMNL Models API**: Automatic support for >=18 different e-paper device models (TRMNL, Seeed Studio, Kobo, Kindle, Nook, …).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Devices model templated are provided by the [TRMNL Models API](https://trmnl.com
 
 Command line wrapper for this package: [epaper-pipeline-cmd](https://github.com/bnussbau/trmnl-pipeline-cmd)
 
-<img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/e84fc752-552e-4cb9-a1c0-aa2596176db7" />
+<img width="800" height="480" alt="browsershot_cham2v3cji4nbZ5JXN6_processed" src="https://github.com/user-attachments/assets/0bb7aa88-3854-4e4b-a67d-3980196027b1" />
+
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/bnussbau/trmnl-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 
 ePaper Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-Paper devices. The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations. This package is used in [usetrmnl/larapaper](https://github.com/usetrmnl/larapaper).
-Devices model templated are provided by the [TRMNL Models API](https://trmnl.com/api/models).
+Devices model presets are provided by the [TRMNL Models API](https://trmnl.com/api/models).
 
 Command line wrapper for this package: [epaper-pipeline-cmd](https://github.com/bnussbau/trmnl-pipeline-cmd)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# TRMNL Pipeline PHP
+# ePaper Pipeline PHP
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/bnussbau/trmnl-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/bnussbau/epaper-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 [![License](https://img.shields.io/badge/License%20-MIT-blue?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 [![Tests](https://img.shields.io/github/actions/workflow/status/bnussbau/trmnl-pipeline-php/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/bnussbau/trmnl-pipeline-php/actions/workflows/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/bnussbau/trmnl-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 
-TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-ink devices supported by the [TRMNL Models API](https://trmnl.com/api/models). The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations. This package is used in [usetrmnl/larapaper](https://github.com/usetrmnl/larapaper).
+ePaper Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-Paper devices. The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations. This package is used in [usetrmnl/larapaper](https://github.com/usetrmnl/larapaper).
+Devices model templated are provided by the [TRMNL Models API](https://trmnl.com/api/models).
 
-Command line wrapper for this package: [trmnl-pipeline-cmd](https://github.com/bnussbau/trmnl-pipeline-cmd)
+Command line wrapper for this package: [epaper-pipeline-cmd](https://github.com/bnussbau/trmnl-pipeline-cmd)
 
 <img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/e84fc752-552e-4cb9-a1c0-aa2596176db7" />
 
@@ -16,7 +17,7 @@ Command line wrapper for this package: [trmnl-pipeline-cmd](https://github.com/b
 
 - **Browser Rendering**: HTML to image conversion using Spatie Browsershot
 - **Image Processing**: Advanced image manipulation using ImageMagick
-- **TRMNL Models API**: Automatic support for >=12 different e-ink device models.
+- **TRMNL Models API**: Automatic support for >=12 different e-paper device models.
 
 ## Requirements
 
@@ -28,7 +29,7 @@ Command line wrapper for this package: [trmnl-pipeline-cmd](https://github.com/b
 You can install the package via composer:
 
 ```bash
-composer require bnussbau/trmnl-pipeline-php
+composer require bnussbau/epaper-pipeline-php
 ```
 
 ## Usage
@@ -37,14 +38,14 @@ composer require bnussbau/trmnl-pipeline-php
 Render HTML and convert to image compatible with the TRMNL OG model.
 
 ```php
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\TrmnlPipeline;
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
-use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\EpaperPipeline;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\Stages\BrowserStage;
 
 $html = file_get_contents('./tests/assets/framework2_og.html');
 
-$image = new TrmnlPipeline()
+$image = new EpaperPipeline()
     ->model(Model::OG)
     ->pipe(new BrowserStage()
         ->html($html))
@@ -58,8 +59,8 @@ Generates PNG 800x480 8-bit Grayscale Gray 4c
 ### Image Processing Only
 
 ```php
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
-use Bnussbau\TrmnlPipeline\Model;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\Model;
 
 $imageStage = new ImageStage();
 $imageStage->configureFromModel(Model::OG_BMP);
@@ -73,14 +74,14 @@ Generates BMP3 800x480 1-bit sRGB 2c
 ### Manual Configuration
 
 ```php
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\TrmnlPipeline;
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
-use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\EpaperPipeline;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\Stages\BrowserStage;
 
 $html = file_get_contents('./tests/assets/framework2_og.html');
 
-$image = new TrmnlPipeline()
+$image = new EpaperPipeline()
     ->pipe(new BrowserStage()
         ->html($html))
     ->pipe(new ImageStage()
@@ -106,13 +107,13 @@ Notes:
 Example:
 
 ```php
-use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
+use Bnussbau\EpaperPipeline\Stages\BrowserStage;
 
-$image = (new \Bnussbau\TrmnlPipeline\TrmnlPipeline())
+$image = (new \Bnussbau\EpaperPipeline\EpaperPipeline())
     ->pipe((new BrowserStage())
         ->timezone('America/New_York')
         ->html('<html><body><script>document.write(new Date().toString())</script></body></html>'))
-    ->pipe(new \Bnussbau\TrmnlPipeline\Stages\ImageStage())
+    ->pipe(new \Bnussbau\EpaperPipeline\Stages\ImageStage())
     ->process();
 ```
 
@@ -122,10 +123,10 @@ You can use different Browsershot implementations (like BrowsershotLambda) by pa
 See installation instructions and requirments for [stefanzweifel/sidecar-browsershot](https://github.com/stefanzweifel/sidecar-browsershot).
 
 ```php
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\TrmnlPipeline;
-use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\EpaperPipeline;
+use Bnussbau\EpaperPipeline\Stages\BrowserStage;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
 use Wnx\SidecarBrowsershot\BrowsershotLambda;
 
 $html = file_get_contents('./tests/assets/framework2_og.html');
@@ -133,7 +134,7 @@ $html = file_get_contents('./tests/assets/framework2_og.html');
 // Create your custom Browsershot instance (e.g., BrowsershotLambda)
 $browsershotLambda = new BrowsershotLambda();
 
-$image = new TrmnlPipeline()
+$image = new EpaperPipeline()
     ->model(Model::OG)
     ->pipe(new BrowserStage($browsershotLambda)
         ->html($html))
@@ -150,17 +151,17 @@ This allows you to use BrowsershotLambda or any other Browsershot implementation
 You can use the `fake()` method to prevent actual Browsershot and Imagick operations:
 
 ```php
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\TrmnlPipeline;
-use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\EpaperPipeline;
+use Bnussbau\EpaperPipeline\Stages\BrowserStage;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
 
 // Enable fake mode for testing
-TrmnlPipeline::fake();
+EpaperPipeline::fake();
 
 $html = '<html><body>Test Content</body></html>';
 
-$result = (new TrmnlPipeline())
+$result = (new EpaperPipeline())
     ->model(Model::OG)
     ->pipe(new BrowserStage()->html($html))
     ->pipe(new ImageStage())
@@ -169,7 +170,7 @@ $result = (new TrmnlPipeline())
 echo "Mock image generated: $result";
 
 // Disable fake mode when done
-TrmnlPipeline::restore();
+EpaperPipeline::restore();
 ```
 
 ## API Reference
@@ -208,7 +209,7 @@ $result = $browserStage(null);
 Screenshot from URL with dithering (recommended for full-color or image-heavy pages):
 
 ```php
-$image = (new TrmnlPipeline())
+$image = (new EpaperPipeline())
     ->model(Model::OG)
     ->pipe((new BrowserStage())->url('https://example.com'))
     ->pipe((new ImageStage())->dither())
@@ -217,7 +218,7 @@ $image = (new TrmnlPipeline())
 
 ### ImageStage
 
-Processes images for e-ink display compatibility.
+Processes images for e-paper display compatibility.
 
 ```php
 $imageStage = new ImageStage();
@@ -240,7 +241,7 @@ $result = $imageStage('/path/to/input.png');
 Recommended for photos but not for images containing mostly text, where it can make edges and letters appear rough or unclear. Dithering converts a grayscale photo into only black and white pixels by using patterns or noise to simulate intermediate shades, creating the illusion of continuous tones through spatial averaging.
 
 ```php
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
 
 (new ImageStage())
     ->dither()
@@ -255,15 +256,15 @@ The pipeline supports color images via palettes defined in `palettes.json`. Mode
 **Example 1: Using Model Preset with Color Palette**
 
 ```php
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\TrmnlPipeline;
-use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\EpaperPipeline;
+use Bnussbau\EpaperPipeline\Stages\BrowserStage;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
 
 $html = file_get_contents('./tests/assets/color_6a_test.html');
 
 // Inky Impression 13.3 model has color-6a palette (6 colors: red, green, blue, yellow, black, white)
-$image = new TrmnlPipeline()
+$image = new EpaperPipeline()
     ->model(Model::INKY_IMPRESSION_13_3)
     ->pipe(new BrowserStage()
         ->html($html))
@@ -276,7 +277,7 @@ echo "Generated color image: $image";
 **Example 2: Defining Color Palette as Array**
 
 ```php
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
 
 // Define custom color palette (6 colors)
 $colorPalette = [

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://img.shields.io/github/actions/workflow/status/bnussbau/trmnl-pipeline-php/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/bnussbau/trmnl-pipeline-php/actions/workflows/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/bnussbau/trmnl-pipeline-php.svg?style=flat-square)](https://packagist.org/packages/bnussbau/trmnl-pipeline-php)
 
-TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-ink devices supported by the [TRMNL Models API](https://trmnl.com/api/models). The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations. This package is used in [usetrmnl/byos_laravel](https://github.com/usetrmnl/byos_laravel).
+TRMNL Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-ink devices supported by the [TRMNL Models API](https://trmnl.com/api/models). The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations. This package is used in [usetrmnl/larapaper](https://github.com/usetrmnl/larapaper).
 
 Command line wrapper for this package: [trmnl-pipeline-cmd](https://github.com/bnussbau/trmnl-pipeline-cmd)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ePaper Pipeline PHP provides a streamlined API, based on the pipeline pattern, for converting HTML content (or images) into optimized images for e-Paper devices. The image processing pipeline includes features like scaling, rotation, grayscale conversion, color quantization, and format-specific optimizations. This package is used in [usetrmnl/larapaper](https://github.com/usetrmnl/larapaper).
 Devices model presets are provided by the [TRMNL Models API](https://trmnl.com/api/models).
 
-Command line wrapper for this package: [epaper-pipeline-cmd](https://github.com/bnussbau/trmnl-pipeline-cmd)
+Command line wrapper for this package: [epaper-pipeline-cmd](https://github.com/bnussbau/epaper-pipeline-cmd)
 
 <img width="800" height="480" alt="browsershot_cham2v3cji4nbZ5JXN6_processed" src="https://github.com/user-attachments/assets/0bb7aa88-3854-4e4b-a67d-3980196027b1" />
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,13 @@
 {
-  "name": "bnussbau/trmnl-render-php",
-  "description": "This is my package trmnl-render-php",
+  "name": "bnussbau/trmnl-pipeline-php",
+  "description": "Convert HTML content into optimized images for a range of e-ink devices.",
   "keywords": [
     "bnussbau",
-    "trmnl-render-php"
+    "trmnl-pipeline-php",
+    "trmnl",
+    "e-ink"
   ],
-  "homepage": "https://github.com/bnussbau/trmnl-render-php",
+  "homepage": "https://github.com/bnussbau/trmnl-pipeline-php",
   "license": "MIT",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-  "name": "bnussbau/trmnl-pipeline-php",
-  "description": "Convert HTML content into optimized images for a range of e-ink devices.",
+  "name": "bnussbau/epaper-pipeline-php",
+  "description": "Convert HTML content into optimized images for a range of e-paper devices.",
   "keywords": [
     "bnussbau",
-    "trmnl-pipeline-php",
-    "trmnl",
-    "e-ink"
+    "epaper-pipeline-php",
+    "epaper",
+    "e-paper"
   ],
-  "homepage": "https://github.com/bnussbau/trmnl-pipeline-php",
+  "homepage": "https://github.com/bnussbau/epaper-pipeline-php",
   "license": "MIT",
   "authors": [
     {
@@ -30,12 +30,12 @@
   },
   "autoload": {
     "psr-4": {
-      "Bnussbau\\TrmnlPipeline\\": "src"
+      "Bnussbau\\EpaperPipeline\\": "src"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Bnussbau\\TrmnlPipeline\\Tests\\": "tests"
+      "Bnussbau\\EpaperPipeline\\Tests\\": "tests"
     }
   },
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "trmnl-render-php",
+    "name": "trmnl-pipeline-php",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "trmnl-pipeline-php",
+    "name": "epaper-pipeline-php",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "dependencies": {
-                "puppeteer": "^24.20.0"
+                "puppeteer": "24.37.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -32,17 +32,17 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.10.10",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.10.tgz",
-            "integrity": "sha512-3ZG500+ZeLql8rE0hjfhkycJjDj0pI/btEh3L9IkWUYcOrgP0xCNRq3HbtbqOPbvDhFaAWD88pDFtlLv8ns8gA==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.0.tgz",
+            "integrity": "sha512-Xuq42yxcQJ54ti8ZHNzF5snFvtpgXzNToJ1bXUGQRaiO8t+B6UM8sTUJfvV+AJnqtkJU/7hdy6nbKyA12aHtRw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "debug": "^4.4.3",
                 "extract-zip": "^2.0.1",
                 "progress": "^2.0.3",
                 "proxy-agent": "^6.5.0",
-                "semver": "^7.7.2",
-                "tar-fs": "^3.1.0",
+                "semver": "^7.7.3",
+                "tar-fs": "^3.1.1",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -59,13 +59,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.4.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.4.0.tgz",
-            "integrity": "sha512-gUuVEAK4/u6F9wRLznPUU4WGUacSEBDPoC2TrBkw3GAnOLHBL45QdfHOXp1kJ4ypBGLxTOB+t7NJLpKoC3gznQ==",
+            "version": "25.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "undici-types": "~7.11.0"
+                "undici-types": "~7.19.0"
             }
         },
         "node_modules/@types/yauzl": {
@@ -130,9 +130,9 @@
             }
         },
         "node_modules/b4a": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.1.tgz",
-            "integrity": "sha512-ZovbrBV0g6JxK5cGUF1Suby1vLfKjv4RWi8IxoaO/Mon8BDD9I21RxjHFtgQ+kskJqLAVyQZly3uMBui+vhc8Q==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+            "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "react-native-b4a": "*"
@@ -144,18 +144,24 @@
             }
         },
         "node_modules/bare-events": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
-            "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+            "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
             "license": "Apache-2.0",
-            "optional": true
+            "peerDependencies": {
+                "bare-abort-controller": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/bare-fs": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.4.4.tgz",
-            "integrity": "sha512-Q8yxM1eLhJfuM7KXVP3zjhBvtMJCYRByoTT+wHXjpdMELv0xICFJX+1w4c7csa+WZEOsq4ItJ4RGwvzid6m/dw==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+            "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
                 "bare-events": "^2.5.4",
                 "bare-path": "^3.0.0",
@@ -176,11 +182,10 @@
             }
         },
         "node_modules/bare-os": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-            "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+            "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
             "license": "Apache-2.0",
-            "optional": true,
             "engines": {
                 "bare": ">=1.14.0"
             }
@@ -190,25 +195,28 @@
             "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
             "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
                 "bare-os": "^3.0.1"
             }
         },
         "node_modules/bare-stream": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-            "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+            "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
-                "streamx": "^2.21.0"
+                "streamx": "^2.25.0",
+                "teex": "^1.0.1"
             },
             "peerDependencies": {
+                "bare-abort-controller": "*",
                 "bare-buffer": "*",
                 "bare-events": "*"
             },
             "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                },
                 "bare-buffer": {
                     "optional": true
                 },
@@ -218,19 +226,18 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.2.2.tgz",
-            "integrity": "sha512-g+ueNGKkrjMazDG3elZO1pNs3HY5+mMmOet1jtKyhOaCnkLzitxf26z7hoAEkDNgdNmnc1KIlt/dw6Po6xZMpA==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+            "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
                 "bare-path": "^3.0.0"
             }
         },
         "node_modules/basic-ftp": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+            "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -255,12 +262,13 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-8.0.0.tgz",
-            "integrity": "sha512-d1VmE0FD7lxZQHzcDUCKZSNRtRwISXDsdg4HjdTR5+Ll5nQ/vzU12JeNmupD6VWffrPSlrnGhEWlLESKH3VO+g==",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.1.0.tgz",
+            "integrity": "sha512-IdGNojX6S04+wgJOALzvkkIyLelhEGqI8xSctwiYJJGSi9T2eBjwAQW2UjBD/mCXv/rUkNlH2+h7jz+58vT74A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "mitt": "^3.0.1",
+                "puppeteer": "^24.36.0",
                 "zod": "^3.24.1"
             },
             "peerDependencies": {
@@ -366,9 +374,9 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1495869",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
-            "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
+            "version": "0.0.1566079",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
+            "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/emoji-regex": {
@@ -463,6 +471,15 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/events-universal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+            "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-events": "^2.7.0"
             }
         },
         "node_modules/extract-zip": {
@@ -581,9 +598,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-            "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+            "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -611,9 +628,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -656,9 +673,9 @@
             "license": "MIT"
         },
         "node_modules/netmask": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+            "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
@@ -782,9 +799,9 @@
             "license": "MIT"
         },
         "node_modules/pump": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
             "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
@@ -792,17 +809,17 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "24.21.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.21.0.tgz",
-            "integrity": "sha512-JNY9JluUXepKzqKoPHsNVsrkpRRTare8geNP2L8YMkFHOKIvWSki/yUL9l2VJpani49epEHLpVg+zDcbTYibWA==",
+            "version": "24.37.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.0.tgz",
+            "integrity": "sha512-s1jHugVhPtQjiJE6wUyonj4VEGWF+mfRDASqPMPsXgKcjZX0GaznBmcT9nLQ7bBL90phuQUqO4jiV5vTecZg4g==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.10.10",
-                "chromium-bidi": "8.0.0",
+                "@puppeteer/browsers": "2.12.0",
+                "chromium-bidi": "13.1.0",
                 "cosmiconfig": "^9.0.0",
-                "devtools-protocol": "0.0.1495869",
-                "puppeteer-core": "24.21.0",
+                "devtools-protocol": "0.0.1566079",
+                "puppeteer-core": "24.37.0",
                 "typed-query-selector": "^2.12.0"
             },
             "bin": {
@@ -813,18 +830,18 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "24.21.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.21.0.tgz",
-            "integrity": "sha512-WR4FehOs4XJ8OSp7MkGyVB4mfMs9Q6t8Y48TxiTCRxc8G2lJ5OKYPJvgU80dtKl+aIqIbdcNTgIooY49S5SsmA==",
+            "version": "24.37.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.0.tgz",
+            "integrity": "sha512-WoCBK36cBlbaxwuvPWhOp2+lR6O6ynHdDuvD8rEIkxPOPpUoMXSJuyiOWhHtexJBCLaMCAJk33QdYambvQl+og==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.10.10",
-                "chromium-bidi": "8.0.0",
+                "@puppeteer/browsers": "2.12.0",
+                "chromium-bidi": "13.1.0",
                 "debug": "^4.4.3",
-                "devtools-protocol": "0.0.1495869",
+                "devtools-protocol": "0.0.1566079",
                 "typed-query-selector": "^2.12.0",
-                "webdriver-bidi-protocol": "0.2.11",
-                "ws": "^8.18.3"
+                "webdriver-bidi-protocol": "0.4.0",
+                "ws": "^8.19.0"
             },
             "engines": {
                 "node": ">=18"
@@ -849,9 +866,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -871,12 +888,12 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+            "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
             "license": "MIT",
             "dependencies": {
-                "ip-address": "^10.0.1",
+                "ip-address": "^10.1.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -909,16 +926,14 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.22.1",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
-            "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+            "version": "2.25.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+            "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
             "license": "MIT",
             "dependencies": {
+                "events-universal": "^1.0.0",
                 "fast-fifo": "^1.3.2",
                 "text-decoder": "^1.1.0"
-            },
-            "optionalDependencies": {
-                "bare-events": "^2.2.0"
             }
         },
         "node_modules/string-width": {
@@ -948,9 +963,9 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-            "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+            "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
             "license": "MIT",
             "dependencies": {
                 "pump": "^3.0.0",
@@ -962,20 +977,30 @@
             }
         },
         "node_modules/tar-stream": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+            "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
             "license": "MIT",
             "dependencies": {
                 "b4a": "^1.6.4",
+                "bare-fs": "^4.5.5",
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
             }
         },
+        "node_modules/teex": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+            "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+            "license": "MIT",
+            "dependencies": {
+                "streamx": "^2.12.5"
+            }
+        },
         "node_modules/text-decoder": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-            "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+            "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.6.4"
@@ -988,22 +1013,22 @@
             "license": "0BSD"
         },
         "node_modules/typed-query-selector": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-            "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+            "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
             "license": "MIT"
         },
         "node_modules/undici-types": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.11.0.tgz",
-            "integrity": "sha512-kt1ZriHTi7MU+Z/r9DOdAI3ONdaR3M3csEaRc6ewa4f4dTvX4cQCbJ4NkEn0ohE4hHtq85+PhPSTY+pO/1PwgA==",
+            "version": "7.19.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
             "license": "MIT",
             "optional": true
         },
         "node_modules/webdriver-bidi-protocol": {
-            "version": "0.2.11",
-            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.2.11.tgz",
-            "integrity": "sha512-Y9E1/oi4XMxcR8AT0ZC4OvYntl34SPgwjmELH+owjBr0korAX4jKgZULBWILGCVGdVCQ0dodTToIETozhG8zvA==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
+            "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
             "license": "Apache-2.0"
         },
         "node_modules/wrap-ansi": {
@@ -1030,9 +1055,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,16 +5,16 @@
     "packages": {
         "": {
             "dependencies": {
-                "puppeteer": "24.37.0"
+                "puppeteer": "^24.37.0"
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -23,25 +23,25 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.0.tgz",
-            "integrity": "sha512-Xuq42yxcQJ54ti8ZHNzF5snFvtpgXzNToJ1bXUGQRaiO8t+B6UM8sTUJfvV+AJnqtkJU/7hdy6nbKyA12aHtRw==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.1.tgz",
+            "integrity": "sha512-zmS4RTK9fbrc++WlAJhxYbfz3IjDeOmkK/CwwbLmk7ydfS9e2CiEeRJHEPvjDVElO/bwXbidwGA37Bsm6LzCnQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "debug": "^4.4.3",
                 "extract-zip": "^2.0.1",
                 "progress": "^2.0.3",
                 "proxy-agent": "^6.5.0",
-                "semver": "^7.7.3",
+                "semver": "^7.7.4",
                 "tar-fs": "^3.1.1",
                 "yargs": "^17.7.2"
             },
@@ -59,9 +59,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.6.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+            "version": "25.6.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+            "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -130,9 +130,9 @@
             }
         },
         "node_modules/b4a": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-            "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+            "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "react-native-b4a": "*"
@@ -182,9 +182,9 @@
             }
         },
         "node_modules/bare-os": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
-            "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+            "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
             "license": "Apache-2.0",
             "engines": {
                 "bare": ">=1.14.0"
@@ -226,9 +226,9 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
-            "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+            "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "bare-path": "^3.0.0"
@@ -262,13 +262,12 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.1.0.tgz",
-            "integrity": "sha512-IdGNojX6S04+wgJOALzvkkIyLelhEGqI8xSctwiYJJGSi9T2eBjwAQW2UjBD/mCXv/rUkNlH2+h7jz+58vT74A==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+            "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "mitt": "^3.0.1",
-                "puppeteer": "^24.36.0",
                 "zod": "^3.24.1"
             },
             "peerDependencies": {
@@ -308,9 +307,9 @@
             "license": "MIT"
         },
         "node_modules/cosmiconfig": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+            "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.1",
@@ -374,9 +373,9 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1566079",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
-            "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
+            "version": "0.0.1608973",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+            "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/emoji-regex": {
@@ -404,9 +403,9 @@
             }
         },
         "node_modules/error-ex": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
             "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
@@ -598,9 +597,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-            "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -809,18 +808,18 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "24.37.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.0.tgz",
-            "integrity": "sha512-s1jHugVhPtQjiJE6wUyonj4VEGWF+mfRDASqPMPsXgKcjZX0GaznBmcT9nLQ7bBL90phuQUqO4jiV5vTecZg4g==",
+            "version": "24.43.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.0.tgz",
+            "integrity": "sha512-DRnMFz+J3s4lFUQcjqKl0/7h0jzlCZuUFU9lNjtKrnMl5WI1RwCaIItpHVu9empuPyUreYueN0sUW3/pnfdqsg==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.12.0",
-                "chromium-bidi": "13.1.0",
+                "@puppeteer/browsers": "2.13.1",
+                "chromium-bidi": "14.0.0",
                 "cosmiconfig": "^9.0.0",
-                "devtools-protocol": "0.0.1566079",
-                "puppeteer-core": "24.37.0",
-                "typed-query-selector": "^2.12.0"
+                "devtools-protocol": "0.0.1608973",
+                "puppeteer-core": "24.43.0",
+                "typed-query-selector": "^2.12.2"
             },
             "bin": {
                 "puppeteer": "lib/cjs/puppeteer/node/cli.js"
@@ -830,18 +829,18 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "24.37.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.0.tgz",
-            "integrity": "sha512-WoCBK36cBlbaxwuvPWhOp2+lR6O6ynHdDuvD8rEIkxPOPpUoMXSJuyiOWhHtexJBCLaMCAJk33QdYambvQl+og==",
+            "version": "24.43.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.0.tgz",
+            "integrity": "sha512-cCRNXsUlhyPoKDz6+TiSpfZpRS3mD6Y1YFKhkdr6ik6TMfuJb7fAtXq9ThUFc4sphxObDk3BuAvdxc1Y6YOnqQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.12.0",
-                "chromium-bidi": "13.1.0",
+                "@puppeteer/browsers": "2.13.1",
+                "chromium-bidi": "14.0.0",
                 "debug": "^4.4.3",
-                "devtools-protocol": "0.0.1566079",
-                "typed-query-selector": "^2.12.0",
-                "webdriver-bidi-protocol": "0.4.0",
-                "ws": "^8.19.0"
+                "devtools-protocol": "0.0.1608973",
+                "typed-query-selector": "^2.12.2",
+                "webdriver-bidi-protocol": "0.4.1",
+                "ws": "^8.20.0"
             },
             "engines": {
                 "node": ">=18"
@@ -866,9 +865,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -888,9 +887,9 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
-            "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+            "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
             "license": "MIT",
             "dependencies": {
                 "ip-address": "^10.1.1",
@@ -1026,9 +1025,9 @@
             "optional": true
         },
         "node_modules/webdriver-bidi-protocol": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
-            "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+            "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
             "license": "Apache-2.0"
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "type": "module",
     "scripts": {},
     "dependencies": {
-        "puppeteer": "^24.20.0"
+        "puppeteer": "24.37.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "type": "module",
     "scripts": {},
     "dependencies": {
-        "puppeteer": "24.37.0"
+        "puppeteer": "^24.37.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         requireCoverageMetadata="false"
+         beStrictAboutCoverageMetadata="false"
+         beStrictAboutOutputDuringTests="false"
+         failOnRisky="false"
+         failOnWarning="false">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Data/ModelData.php
+++ b/src/Data/ModelData.php
@@ -26,6 +26,8 @@ readonly class ModelData
         public int $offsetY,
         public string $publishedAt,
         public string $kind,
+        /** @var array<string> */
+        public array $paletteIds,
     ) {}
 
     /**
@@ -82,6 +84,7 @@ readonly class ModelData
                 offsetY: (int) ($modelData['offset_y'] ?? 0),
                 publishedAt: $modelData['published_at'] ?? '',
                 kind: $modelData['kind'] ?? '',
+                paletteIds: $modelData['palette_ids'] ?? [],
             );
         }
 

--- a/src/Data/ModelData.php
+++ b/src/Data/ModelData.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Bnussbau\TrmnlPipeline\Data;
+namespace Bnussbau\EpaperPipeline\Data;
 
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 
 /**
  * Model data structure loaded from models.json

--- a/src/Data/PaletteData.php
+++ b/src/Data/PaletteData.php
@@ -23,13 +23,14 @@ readonly class PaletteData
     /**
      * Load palette data from JSON file
      *
+     * @param  string|null  $jsonPath  Optional path to JSON file (defaults to palettes.json in package)
      * @return array<string, PaletteData>
      *
      * @throws ProcessingException
      */
-    public static function loadFromJson(): array
+    public static function loadFromJson(?string $jsonPath = null): array
     {
-        $jsonPath = __DIR__.'/palettes.json';
+        $jsonPath = $jsonPath ?? __DIR__.'/palettes.json';
 
         if (! file_exists($jsonPath)) {
             throw new ProcessingException("Palettes JSON file not found at: {$jsonPath}");

--- a/src/Data/PaletteData.php
+++ b/src/Data/PaletteData.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bnussbau\TrmnlPipeline\Data;
+
+use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
+
+/**
+ * Palette data structure loaded from palettes.json
+ */
+readonly class PaletteData
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public int $grays,
+        /** @var array<string>|null */
+        public ?array $colors,
+        public string $frameworkClass,
+    ) {}
+
+    /**
+     * Load palette data from JSON file
+     *
+     * @return array<string, PaletteData>
+     *
+     * @throws ProcessingException
+     */
+    public static function loadFromJson(): array
+    {
+        $jsonPath = __DIR__.'/palettes.json';
+
+        if (! file_exists($jsonPath)) {
+            throw new ProcessingException("Palettes JSON file not found at: {$jsonPath}");
+        }
+
+        $jsonContent = file_get_contents($jsonPath);
+        if ($jsonContent === false) {
+            throw new ProcessingException('Failed to read palettes JSON file');
+        }
+
+        $data = json_decode($jsonContent, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new ProcessingException('Invalid JSON in palettes file: '.json_last_error_msg());
+        }
+
+        if (! is_array($data)) {
+            throw new ProcessingException('Invalid JSON structure: expected array');
+        }
+
+        if (! isset($data['data']) || ! is_array($data['data'])) {
+            throw new ProcessingException("Invalid palettes JSON structure: missing 'data' array");
+        }
+
+        $palettes = [];
+        foreach ($data['data'] as $paletteData) {
+            if (! isset($paletteData['id'])) {
+                throw new ProcessingException("Palette data missing required 'id' field");
+            }
+
+            $palettes[$paletteData['id']] = new self(
+                id: $paletteData['id'],
+                name: $paletteData['name'] ?? '',
+                grays: (int) ($paletteData['grays'] ?? 0),
+                colors: $paletteData['colors'] ?? null,
+                frameworkClass: $paletteData['framework_class'] ?? '',
+            );
+        }
+
+        return $palettes;
+    }
+
+    public static function getById(string $id): ?self
+    {
+        $palettes = self::loadFromJson();
+
+        if (! isset($palettes[$id])) {
+            return null;
+        }
+
+        return $palettes[$id];
+    }
+
+    /**
+     * Get all available palette IDs
+     *
+     * @return array<string>
+     *
+     * @throws ProcessingException
+     */
+    public static function getAllIds(): array
+    {
+        $palettes = self::loadFromJson();
+
+        return array_keys($palettes);
+    }
+}

--- a/src/Data/PaletteData.php
+++ b/src/Data/PaletteData.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Bnussbau\TrmnlPipeline\Data;
+namespace Bnussbau\EpaperPipeline\Data;
 
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 
 /**
  * Palette data structure loaded from palettes.json

--- a/src/Data/models.json
+++ b/src/Data/models.json
@@ -172,6 +172,7 @@
             "kind": "byod",
             "palette_ids": [
                 "color-7a",
+                "color-6a",
                 "bw"
             ]
         },
@@ -364,7 +365,7 @@
             "width": 800,
             "height": 480,
             "colors": 4,
-            "bit_depth": 2,
+            "bit_depth": 8,
             "scale_factor": 1.0,
             "rotation": 0,
             "mime_type": "image/png",
@@ -373,6 +374,8 @@
             "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "byod",
             "palette_ids": [
+                "color-spectra6",
+                "color-6a",
                 "gray-4",
                 "bw"
             ]

--- a/src/Data/models.json
+++ b/src/Data/models.json
@@ -14,7 +14,10 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "trmnl"
+            "kind": "trmnl",
+            "palette_ids": [
+                "bw"
+            ]
         },
         {
             "name": "og_bmp",
@@ -30,7 +33,10 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "trmnl"
+            "kind": "trmnl",
+            "palette_ids": [
+                "bw"
+            ]
         },
         {
             "name": "amazon_kindle_2024",
@@ -40,13 +46,16 @@
             "height": 840,
             "colors": 256,
             "bit_depth": 8,
-            "scale_factor": 2.414,
+            "scale_factor": 1.75,
             "rotation": 90,
             "mime_type": "image/png",
             "offset_x": 75,
             "offset_y": 25,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "kindle"
+            "kind": "kindle",
+            "palette_ids": [
+                "gray-256"
+            ]
         },
         {
             "name": "amazon_kindle_paperwhite_6th_gen",
@@ -62,7 +71,10 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "kindle"
+            "kind": "kindle",
+            "palette_ids": [
+                "gray-256"
+            ]
         },
         {
             "name": "amazon_kindle_paperwhite_7th_gen",
@@ -78,7 +90,10 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "kindle"
+            "kind": "kindle",
+            "palette_ids": [
+                "gray-256"
+            ]
         },
         {
             "name": "inkplate_10",
@@ -94,7 +109,11 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "byod"
+            "kind": "byod",
+            "palette_ids": [
+                "gray-4",
+                "bw"
+            ]
         },
         {
             "name": "amazon_kindle_7",
@@ -110,7 +129,10 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "kindle"
+            "kind": "kindle",
+            "palette_ids": [
+                "gray-256"
+            ]
         },
         {
             "name": "inky_impression_7_3",
@@ -126,7 +148,11 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "byod"
+            "kind": "byod",
+            "palette_ids": [
+                "color-7a",
+                "bw"
+            ]
         },
         {
             "name": "kobo_libra_2",
@@ -142,7 +168,12 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "byod"
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ]
         },
         {
             "name": "amazon_kindle_oasis_2",
@@ -158,7 +189,10 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "byod"
+            "kind": "byod",
+            "palette_ids": [
+                "gray-256"
+            ]
         },
         {
             "name": "og_plus",
@@ -174,7 +208,11 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "trmnl"
+            "kind": "trmnl",
+            "palette_ids": [
+                "gray-4",
+                "bw"
+            ]
         },
         {
             "name": "kobo_aura_one",
@@ -190,7 +228,12 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "byod"
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ]
         },
         {
             "name": "kobo_aura_hd",
@@ -206,7 +249,12 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "byod"
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ]
         },
         {
             "name": "inky_impression_13_3",
@@ -222,7 +270,32 @@
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "byod"
+            "kind": "byod",
+            "palette_ids": [
+                "color-6a",
+                "bw"
+            ]
+        },
+        {
+            "name": "m5_paper_s3",
+            "label": "M5PaperS3",
+            "description": "M5PaperS3",
+            "width": 960,
+            "height": 540,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "published_at": "2024-01-01T00:00:00.000Z",
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ]
         }
     ]
 }

--- a/src/Data/models.json
+++ b/src/Data/models.json
@@ -39,6 +39,27 @@
             ]
         },
         {
+            "name": "v2",
+            "label": "TRMNL X",
+            "description": "TRMNL X",
+            "width": 1872,
+            "height": 1404,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 1.8,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "published_at": "2024-01-01T00:00:00.000Z",
+            "kind": "trmnl",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ]
+        },
+        {
             "name": "amazon_kindle_2024",
             "label": "Amazon Kindle 2024",
             "description": "Amazon Kindle 2024",
@@ -65,7 +86,7 @@
             "height": 768,
             "colors": 256,
             "bit_depth": 8,
-            "scale_factor": 1.0,
+            "scale_factor": 1.28,
             "rotation": 90,
             "mime_type": "image/png",
             "offset_x": 0,
@@ -84,7 +105,7 @@
             "height": 1072,
             "colors": 256,
             "bit_depth": 8,
-            "scale_factor": 1.0,
+            "scale_factor": 1.6,
             "rotation": 90,
             "mime_type": "image/png",
             "offset_x": 0,
@@ -183,13 +204,13 @@
             "height": 1264,
             "colors": 256,
             "bit_depth": 8,
-            "scale_factor": 1.0,
+            "scale_factor": 2.1,
             "rotation": 90,
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
             "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "byod",
+            "kind": "kindle",
             "palette_ids": [
                 "gray-256"
             ]
@@ -294,6 +315,104 @@
             "palette_ids": [
                 "gray-16",
                 "gray-4",
+                "bw"
+            ]
+        },
+        {
+            "name": "amazon_kindle_scribe",
+            "label": "Amazon Kindle Scribe",
+            "description": "Amazon Kindle Scribe",
+            "width": 2480,
+            "height": 1860,
+            "colors": 256,
+            "bit_depth": 8,
+            "scale_factor": 2.5,
+            "rotation": 90,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "published_at": "2024-01-01T00:00:00.000Z",
+            "kind": "kindle",
+            "palette_ids": [
+                "gray-256"
+            ]
+        },
+        {
+            "name": "seeed_e1001",
+            "label": "Seeed E1001 Monochrome",
+            "description": "Seeed E1001 Monochrome",
+            "width": 800,
+            "height": 480,
+            "colors": 4,
+            "bit_depth": 2,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "published_at": "2024-01-01T00:00:00.000Z",
+            "kind": "byod",
+            "palette_ids": [
+                "gray-4",
+                "bw"
+            ]
+        },
+        {
+            "name": "seeed_e1002",
+            "label": "Seeed E1002 (2-bit)",
+            "description": "Seeed E1002 (2-bit)",
+            "width": 800,
+            "height": 480,
+            "colors": 4,
+            "bit_depth": 2,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "published_at": "2024-01-01T00:00:00.000Z",
+            "kind": "byod",
+            "palette_ids": [
+                "gray-4",
+                "bw"
+            ]
+        },
+        {
+            "name": "waveshare_4_26",
+            "label": "Waveshare 4.26 (2-bit)",
+            "description": "Waveshare 4.26 (2-bit)",
+            "width": 800,
+            "height": 480,
+            "colors": 4,
+            "bit_depth": 2,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "published_at": "2024-01-01T00:00:00.000Z",
+            "kind": "byod",
+            "palette_ids": [
+                "gray-4",
+                "bw"
+            ]
+        },
+        {
+            "name": "waveshare_7_5_bw",
+            "label": "Waveshare 7.5 B/W",
+            "description": "Waveshare 7.5 B/W",
+            "width": 800,
+            "height": 480,
+            "colors": 2,
+            "bit_depth": 1,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "published_at": "2024-01-01T00:00:00.000Z",
+            "kind": "byod",
+            "palette_ids": [
                 "bw"
             ]
         }

--- a/src/Data/models.json
+++ b/src/Data/models.json
@@ -13,11 +13,46 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "trmnl",
             "palette_ids": [
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--og_png",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "og_bmp",
@@ -51,13 +86,48 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "trmnl",
             "palette_ids": [
                 "gray-16",
                 "gray-4",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--v2",
+                    "size": "screen--lg",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1040px"
+                    ],
+                    [
+                        "--screen-h",
+                        "780px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.8"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "amazon_kindle_2024",
@@ -72,11 +142,46 @@
             "mime_type": "image/png",
             "offset_x": 75,
             "offset_y": 25,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "kindle",
             "palette_ids": [
                 "gray-256"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 512000,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--amazon_kindle_2024",
+                    "size": "screen--sm",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.75"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "0.8"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "amazon_kindle_paperwhite_6th_gen",
@@ -91,11 +196,46 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "kindle",
             "palette_ids": [
                 "gray-256"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 512000,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--amazon_kindle_paperwhite_6th_gen",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "600px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.28"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "amazon_kindle_paperwhite_7th_gen",
@@ -110,31 +250,101 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "kindle",
             "palette_ids": [
                 "gray-256"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 512000,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--amazon_kindle_paperwhite_7th_gen",
+                    "size": "screen--md",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "905px"
+                    ],
+                    [
+                        "--screen-h",
+                        "670px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.6"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "inkplate_10",
             "label": "Inkplate 10",
             "description": "Inkplate 10",
             "width": 1200,
-            "height": 820,
+            "height": 825,
             "colors": 8,
             "bit_depth": 3,
-            "scale_factor": 1.0,
+            "scale_factor": 1.5,
             "rotation": 0,
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "byod",
             "palette_ids": [
                 "gray-4",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--inkplate_10",
+                    "size": "screen--md",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "550px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.5"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "amazon_kindle_7",
@@ -149,11 +359,46 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "kindle",
             "palette_ids": [
                 "gray-256"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 512000,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--amazon_kindle_7",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "600px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "inky_impression_7_3",
@@ -168,13 +413,48 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "byod",
             "palette_ids": [
                 "color-7a",
                 "color-6a",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "limited",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--inky_impression_7_3",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "kobo_libra_2",
@@ -184,18 +464,53 @@
             "height": 1264,
             "colors": 256,
             "bit_depth": 8,
-            "scale_factor": 1.0,
-            "rotation": 90,
+            "scale_factor": 2.0,
+            "rotation": 0,
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "byod",
             "palette_ids": [
                 "gray-16",
                 "gray-4",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--kobo_libra_2",
+                    "size": "screen--md",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "840px"
+                    ],
+                    [
+                        "--screen-h",
+                        "632px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "amazon_kindle_oasis_2",
@@ -210,11 +525,46 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "kindle",
             "palette_ids": [
                 "gray-256"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 512000,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--amazon_kindle_oasis_2",
+                    "size": "screen--md",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "602px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "2.1"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "og_plus",
@@ -229,12 +579,47 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "trmnl",
             "palette_ids": [
                 "gray-4",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--ogv2",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "kobo_aura_one",
@@ -244,18 +629,53 @@
             "height": 1404,
             "colors": 256,
             "bit_depth": 8,
-            "scale_factor": 1.0,
-            "rotation": 90,
+            "scale_factor": 1.8,
+            "rotation": 0,
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "byod",
             "palette_ids": [
                 "gray-16",
                 "gray-4",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--kobo_aura_one",
+                    "size": "screen--lg",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1040px"
+                    ],
+                    [
+                        "--screen-h",
+                        "780px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.8"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "kobo_aura_hd",
@@ -265,18 +685,53 @@
             "height": 1080,
             "colors": 16,
             "bit_depth": 4,
-            "scale_factor": 1.0,
-            "rotation": 90,
+            "scale_factor": 1.8,
+            "rotation": 0,
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "byod",
             "palette_ids": [
                 "gray-16",
                 "gray-4",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--kobo_aura_hd",
+                    "size": "screen--md",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "600px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.8"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "inky_impression_13_3",
@@ -286,17 +741,52 @@
             "height": 1200,
             "colors": 2,
             "bit_depth": 1,
-            "scale_factor": 1.0,
+            "scale_factor": 2.0,
             "rotation": 0,
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "byod",
             "palette_ids": [
                 "color-6a",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "limited",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--inky_impression_13_3",
+                    "size": "screen--md",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "600px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "m5_paper_s3",
@@ -311,13 +801,48 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "byod",
             "palette_ids": [
                 "gray-16",
                 "gray-4",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--m5_paper_s3",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "960px"
+                    ],
+                    [
+                        "--screen-h",
+                        "540px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "amazon_kindle_scribe",
@@ -332,11 +857,46 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "kindle",
             "palette_ids": [
                 "gray-256"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 512000,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--amazon_kindle_scribe",
+                    "size": "screen--lg",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "992px"
+                    ],
+                    [
+                        "--screen-h",
+                        "744px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "2.5"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "seeed_e1001",
@@ -351,39 +911,52 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "byod",
             "palette_ids": [
                 "gray-4",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--ogv2",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "seeed_e1002",
             "label": "Seeed E1002 (2-bit)",
             "description": "Seeed E1002 (2-bit)",
-            "width": 800,
-            "height": 480,
-            "colors": 4,
-            "bit_depth": 8,
-            "scale_factor": 1.0,
-            "rotation": 0,
-            "mime_type": "image/png",
-            "offset_x": 0,
-            "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
-            "kind": "byod",
-            "palette_ids": [
-                "color-spectra6",
-                "color-6a",
-                "gray-4",
-                "bw"
-            ]
-        },
-        {
-            "name": "waveshare_4_26",
-            "label": "Waveshare 4.26 (2-bit)",
-            "description": "Waveshare 4.26 (2-bit)",
             "width": 800,
             "height": 480,
             "colors": 4,
@@ -393,17 +966,107 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
+            "kind": "byod",
+            "palette_ids": [
+                "color-6a",
+                "bw"
+            ],
+            "preview_white_point": "limited",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--ogv2",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "waveshare_4_26",
+            "label": "Waveshare 4.26\" (2-bit)",
+            "description": "Waveshare 4.26\" (2-bit)",
+            "width": 800,
+            "height": 480,
+            "colors": 4,
+            "bit_depth": 2,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
             "kind": "byod",
             "palette_ids": [
                 "gray-4",
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--ogv2",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         },
         {
             "name": "waveshare_7_5_bw",
-            "label": "Waveshare 7.5 B/W",
-            "description": "Waveshare 7.5 B/W",
+            "label": "Waveshare 7.5\" B/W",
+            "description": "Waveshare 7.5\" B/W",
             "width": 800,
             "height": 480,
             "colors": 2,
@@ -413,11 +1076,1269 @@
             "mime_type": "image/png",
             "offset_x": 0,
             "offset_y": 0,
-            "published_at": "2024-01-01T00:00:00.000Z",
             "kind": "byod",
             "palette_ids": [
                 "bw"
-            ]
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--og",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "generic_16_9",
+            "label": "Generic 16:9 Display",
+            "description": "Generic 16:9 Display",
+            "width": 1920,
+            "height": 1080,
+            "colors": 256,
+            "bit_depth": 8,
+            "scale_factor": 2.4,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-256",
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--generic_16_9",
+                    "size": "screen--md",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "450px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "2.4"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "palma",
+            "label": "Onyx BOOX Palma",
+            "description": "Onyx BOOX Palma",
+            "width": 1648,
+            "height": 824,
+            "colors": 256,
+            "bit_depth": 8,
+            "scale_factor": 2.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-256"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--palma",
+                    "size": "screen--md",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "824px"
+                    ],
+                    [
+                        "--screen-h",
+                        "412px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "0.8"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "onyx_boox_go_7",
+            "label": "Onyx BOOX Go 7",
+            "description": "Onyx BOOX Go 7",
+            "width": 1880,
+            "height": 1264,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 1.8008,
+            "rotation": 90,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--onyx_boox_go_7",
+                    "size": "screen--lg",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1044px"
+                    ],
+                    [
+                        "--screen-h",
+                        "702px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.8008"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "kobo_glo",
+            "label": "Kobo Glo",
+            "description": "Kobo Glo",
+            "width": 1024,
+            "height": 768,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 1.2995,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--kobo_glo",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "788px"
+                    ],
+                    [
+                        "--screen-h",
+                        "591px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.2995"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "waveshare_7_5_bwr",
+            "label": "Waveshare 7.5\" B/W/R",
+            "description": "Waveshare 7.5\" B/W/R",
+            "width": 800,
+            "height": 480,
+            "colors": 2,
+            "bit_depth": 1,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "color-3bwr"
+            ],
+            "preview_white_point": "limited",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--og",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "waveshare_7_5_bwry",
+            "label": "Waveshare 7.5\" B/W/R/Y",
+            "description": "Waveshare 7.5\" B/W/R/Y",
+            "width": 800,
+            "height": 480,
+            "colors": 2,
+            "bit_depth": 1,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "color-4bwry"
+            ],
+            "preview_white_point": "limited",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--og",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "onxy_boox_nova_air_c",
+            "label": "Onyx BOOX Nova Air C",
+            "description": "Onyx BOOX Nova Air C",
+            "width": 1872,
+            "height": 1404,
+            "colors": 4096,
+            "bit_depth": 12,
+            "scale_factor": 1.8,
+            "rotation": 90,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "color-12bit",
+                "gray-256",
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "limited",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--onxy_boox_nova_air_c",
+                    "size": "screen--lg",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1040px"
+                    ],
+                    [
+                        "--screen-h",
+                        "780px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.8"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "xteink_x4",
+            "label": "Xteink X4",
+            "description": "Xteink X4",
+            "width": 800,
+            "height": 480,
+            "colors": 4,
+            "bit_depth": 2,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--ogv2",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "nook_simple_touch",
+            "label": "Nook Simple Touch",
+            "description": "Nook Simple Touch",
+            "width": 800,
+            "height": 600,
+            "colors": 256,
+            "bit_depth": 8,
+            "scale_factor": 1.0,
+            "rotation": 90,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "kindle",
+            "palette_ids": [
+                "gray-256",
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 512000,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--nook_simple_touch",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "600px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "kobo_sage",
+            "label": "Kobo Sage",
+            "description": "Kobo Sage",
+            "width": 1920,
+            "height": 1440,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 1.4004,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--kobo_sage",
+                    "size": "screen--lg",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1371px"
+                    ],
+                    [
+                        "--screen-h",
+                        "1028px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.4004"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "og_bwry",
+            "label": "TRMNL OG (B/W/R/Y)",
+            "description": "TRMNL OG (B/W/R/Y)",
+            "width": 800,
+            "height": 480,
+            "colors": 2,
+            "bit_depth": 1,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "trmnl",
+            "palette_ids": [
+                "color-4bwry"
+            ],
+            "preview_white_point": "limited",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--og",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "amazon_kindle_voyage",
+            "label": "Amazon Kindle Voyage",
+            "description": "Amazon Kindle Voyage",
+            "width": 1448,
+            "height": 1072,
+            "colors": 256,
+            "bit_depth": 8,
+            "scale_factor": 1.4008,
+            "rotation": 90,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "kindle",
+            "palette_ids": [
+                "gray-256"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 512000,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--amazon_kindle_voyage",
+                    "size": "screen--lg",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1034px"
+                    ],
+                    [
+                        "--screen-h",
+                        "765px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.4008"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "inkplate_5_2",
+            "label": "Inkplate 5.2",
+            "description": "Inkplate 5.2",
+            "width": 1280,
+            "height": 720,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 1.1996,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--inkplate_5_2",
+                    "size": "screen--lg",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1067px"
+                    ],
+                    [
+                        "--screen-h",
+                        "600px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.1996"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "raspberry_pi_touch_2",
+            "label": "Raspberry Pi Touch 2",
+            "description": "Raspberry Pi Touch 2",
+            "width": 1280,
+            "height": 720,
+            "colors": 16777216,
+            "bit_depth": 24,
+            "scale_factor": 1.1996,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "color-24bit"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--raspberry_pi_touch_2",
+                    "size": "screen--lg",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1067px"
+                    ],
+                    [
+                        "--screen-h",
+                        "600px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.1996"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "ed133ut2",
+            "label": "ED133UT2 Active Matrix",
+            "description": "ED133UT2 Active Matrix",
+            "width": 1600,
+            "height": 1200,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 1.5385,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--ed133ut2",
+                    "size": "screen--lg",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1040px"
+                    ],
+                    [
+                        "--screen-h",
+                        "780px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.5385"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "avalue_epd_42s",
+            "label": "Avalue EPD-42S 42\" Display Board",
+            "description": "Avalue EPD-42S 42\" Display Board",
+            "width": 2880,
+            "height": 2160,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 2.7692,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--avalue_epd_42s",
+                    "size": "screen--lg",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1040px"
+                    ],
+                    [
+                        "--screen-h",
+                        "780px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "2.7692"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "kobo_touch",
+            "label": "Kobo Touch",
+            "description": "Kobo Touch",
+            "width": 800,
+            "height": 600,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--kobo_touch",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "600px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "kobo_forma",
+            "label": "Kobo Forma",
+            "description": "Kobo Forma",
+            "width": 1920,
+            "height": 1440,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 1.4004,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--kobo_forma",
+                    "size": "screen--lg",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1371px"
+                    ],
+                    [
+                        "--screen-h",
+                        "1028px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.4004"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "openframe",
+            "label": "OpenPeak OpenFrame",
+            "description": "OpenPeak OpenFrame",
+            "width": 800,
+            "height": 480,
+            "colors": 16777216,
+            "bit_depth": 24,
+            "scale_factor": 1.0,
+            "rotation": 0,
+            "mime_type": "image/webp",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "color-24bit",
+                "gray-256",
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--openframe",
+                    "size": "screen--md",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "480px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "amazon_kindle_paperwhite_signature_11th_gen",
+            "label": "Amazon Kindle PW Signature 11th Gen",
+            "description": "Amazon Kindle PW Signature 11th Gen",
+            "width": 1648,
+            "height": 1236,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 2.06,
+            "rotation": 90,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "kindle",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 512000,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--amazon_kindle_paperwhite_signature_11th_gen",
+                    "size": "screen--md",
+                    "density": "screen--density-2x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "800px"
+                    ],
+                    [
+                        "--screen-h",
+                        "600px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "2.06"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "2.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "inkplate_6_plus",
+            "label": "Inkplate 6 Plus",
+            "description": "Inkplate 6 Plus",
+            "width": 1024,
+            "height": 758,
+            "colors": 4,
+            "bit_depth": 2,
+            "scale_factor": 0.9846,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--inkplate_6_plus",
+                    "size": "screen--lg",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1040px"
+                    ],
+                    [
+                        "--screen-h",
+                        "770px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "0.9846"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
+        },
+        {
+            "name": "kobo_aura_h2o_2",
+            "label": "Kobo Aura H2O Edition 2",
+            "description": "Kobo Aura H2O Edition 2",
+            "width": 1430,
+            "height": 1080,
+            "colors": 16,
+            "bit_depth": 4,
+            "scale_factor": 1.375,
+            "rotation": 0,
+            "mime_type": "image/png",
+            "offset_x": 0,
+            "offset_y": 0,
+            "kind": "byod",
+            "palette_ids": [
+                "gray-16",
+                "gray-4",
+                "bw"
+            ],
+            "preview_white_point": "true_white",
+            "image_size_limit": 92160,
+            "image_upload_supported": true,
+            "css": {
+                "classes": {
+                    "device": "screen--kobo_aura_h2o_2",
+                    "size": "screen--lg",
+                    "density": "screen--density-1x"
+                },
+                "variables": [
+                    [
+                        "--screen-w",
+                        "1040px"
+                    ],
+                    [
+                        "--screen-h",
+                        "785px"
+                    ],
+                    [
+                        "--pixel-ratio",
+                        "1.375"
+                    ],
+                    [
+                        "--dither-pixel-ratio",
+                        "1.0"
+                    ],
+                    [
+                        "--ui-scale",
+                        "1.0"
+                    ],
+                    [
+                        "--gap-scale",
+                        "1.0"
+                    ]
+                ]
+            }
         }
     ]
 }

--- a/src/Data/palettes.json
+++ b/src/Data/palettes.json
@@ -1,0 +1,61 @@
+{
+    "data": [
+        {
+            "id": "bw",
+            "name": "Black \u0026 White",
+            "grays": 2,
+            "colors": null,
+            "framework_class": "screen--1bit"
+        },
+        {
+            "id": "gray-4",
+            "name": "4 Grays",
+            "grays": 4,
+            "colors": null,
+            "framework_class": "screen--2bit"
+        },
+        {
+            "id": "gray-16",
+            "name": "16 Grays",
+            "grays": 16,
+            "colors": null,
+            "framework_class": "screen--4bit"
+        },
+        {
+            "id": "gray-256",
+            "name": "256 Grays",
+            "grays": 256,
+            "colors": null,
+            "framework_class": "screen--4bit"
+        },
+        {
+            "id": "color-6a",
+            "name": "Color (6 colors)",
+            "grays": 2,
+            "colors": [
+                "#FF0000",
+                "#00FF00",
+                "#0000FF",
+                "#FFFF00",
+                "#000000",
+                "#FFFFFF"
+            ],
+            "framework_class": ""
+        },
+        {
+            "id": "color-7a",
+            "name": "Color (7 colors)",
+            "grays": 2,
+            "colors": [
+                "#000000",
+                "#FFFFFF",
+                "#FF0000",
+                "#00FF00",
+                "#0000FF",
+                "#FFFF00",
+                "#FFA500"
+            ],
+            "framework_class": ""
+        }
+    ]
+}

--- a/src/Data/palettes.json
+++ b/src/Data/palettes.json
@@ -2,31 +2,71 @@
     "data": [
         {
             "id": "bw",
-            "name": "Black \u0026 White",
+            "name": "Black & White (1-bit)",
             "grays": 2,
-            "colors": null,
             "framework_class": "screen--1bit"
         },
         {
             "id": "gray-4",
-            "name": "4 Grays",
+            "name": "4 Grays (2-bit)",
             "grays": 4,
-            "colors": null,
             "framework_class": "screen--2bit"
         },
         {
             "id": "gray-16",
-            "name": "16 Grays",
+            "name": "16 Grays (4-bit)",
             "grays": 16,
-            "colors": null,
             "framework_class": "screen--4bit"
         },
         {
             "id": "gray-256",
-            "name": "256 Grays",
+            "name": "256 Grays (8-bit)",
             "grays": 256,
-            "colors": null,
             "framework_class": "screen--4bit"
+        },
+        {
+            "id": "color-3bwr",
+            "name": "Color (3 colors)",
+            "grays": 2,
+            "colors": [
+                "#000000",
+                "#FF0000",
+                "#FFFFFF"
+            ]
+        },
+        {
+            "id": "color-3bwy",
+            "name": "Color (3 colors)",
+            "grays": 2,
+            "colors": [
+                "#000000",
+                "#FFFF00",
+                "#FFFFFF"
+            ]
+        },
+        {
+            "id": "color-4bwry",
+            "name": "Color (4 colors)",
+            "grays": 2,
+            "colors": [
+                "#000000",
+                "#FF0000",
+                "#FFFFFF",
+                "#FFFF00"
+            ]
+        },
+        {
+            "id": "color-spectra6",
+            "name": "Color (6 colors)",
+            "grays": 2,
+            "colors": [
+                "#52180A",
+                "#59683F",
+                "#28487B",
+                "#968327",
+                "#000000",
+                "#FFFFFF"
+            ]
         },
         {
             "id": "color-6a",
@@ -39,8 +79,7 @@
                 "#FFFF00",
                 "#000000",
                 "#FFFFFF"
-            ],
-            "framework_class": ""
+            ]
         },
         {
             "id": "color-7a",
@@ -54,8 +93,17 @@
                 "#0000FF",
                 "#FFFF00",
                 "#FFA500"
-            ],
-            "framework_class": ""
+            ]
+        },
+        {
+            "id": "color-12bit",
+            "name": "Color (4096 colors)",
+            "grays": 2
+        },
+        {
+            "id": "color-24bit",
+            "name": "Color (16777216 colors)",
+            "grays": 2
         }
     ]
 }

--- a/src/Data/palettes.json
+++ b/src/Data/palettes.json
@@ -2,7 +2,7 @@
     "data": [
         {
             "id": "bw",
-            "name": "Black & White (1-bit)",
+            "name": "Black \u0026 White (1-bit)",
             "grays": 2,
             "framework_class": "screen--1bit"
         },
@@ -32,7 +32,9 @@
                 "#000000",
                 "#FF0000",
                 "#FFFFFF"
-            ]
+            ],
+            "framework_class": "screen--color-3bwr",
+            "grayscale_bit_depth": 1
         },
         {
             "id": "color-3bwy",
@@ -42,7 +44,9 @@
                 "#000000",
                 "#FFFF00",
                 "#FFFFFF"
-            ]
+            ],
+            "framework_class": "screen--color-3bwy",
+            "grayscale_bit_depth": 1
         },
         {
             "id": "color-4bwry",
@@ -53,20 +57,9 @@
                 "#FF0000",
                 "#FFFFFF",
                 "#FFFF00"
-            ]
-        },
-        {
-            "id": "color-spectra6",
-            "name": "Color (6 colors)",
-            "grays": 2,
-            "colors": [
-                "#52180A",
-                "#59683F",
-                "#28487B",
-                "#968327",
-                "#000000",
-                "#FFFFFF"
-            ]
+            ],
+            "framework_class": "screen--color-4bwry",
+            "grayscale_bit_depth": 1
         },
         {
             "id": "color-6a",
@@ -79,7 +72,9 @@
                 "#FFFF00",
                 "#000000",
                 "#FFFFFF"
-            ]
+            ],
+            "framework_class": "screen--color-6a",
+            "grayscale_bit_depth": 1
         },
         {
             "id": "color-7a",
@@ -93,17 +88,23 @@
                 "#0000FF",
                 "#FFFF00",
                 "#FFA500"
-            ]
+            ],
+            "framework_class": "screen--color-7a",
+            "grayscale_bit_depth": 1
         },
         {
             "id": "color-12bit",
             "name": "Color (4096 colors)",
-            "grays": 2
+            "grays": 2,
+            "framework_class": "screen--color-full",
+            "grayscale_bit_depth": 4
         },
         {
             "id": "color-24bit",
             "name": "Color (16777216 colors)",
-            "grays": 2
+            "grays": 2,
+            "framework_class": "screen--color-full",
+            "grayscale_bit_depth": 4
         }
     ]
 }

--- a/src/EpaperPipeline.php
+++ b/src/EpaperPipeline.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Bnussbau\TrmnlPipeline;
+namespace Bnussbau\EpaperPipeline;
 
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 use League\Pipeline\Pipeline;
 
 /**
- * Main pipeline class for e-ink image processing
+ * Main pipeline class for e-paper image processing
  */
-class TrmnlPipeline
+class EpaperPipeline
 {
     private ?Model $model = null;
 

--- a/src/Exceptions/ProcessingException.php
+++ b/src/Exceptions/ProcessingException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Bnussbau\TrmnlPipeline\Exceptions;
+namespace Bnussbau\EpaperPipeline\Exceptions;
 
 use Exception;
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -24,6 +24,7 @@ enum Model: string
     case KOBO_AURA_ONE = 'kobo_aura_one';
     case KOBO_AURA_HD = 'kobo_aura_hd';
     case INKY_IMPRESSION_13_3 = 'inky_impression_13_3';
+    case M5_PAPER_S3 = 'm5_paper_s3';
 
     /**
      * Get the model data from JSON
@@ -96,6 +97,18 @@ enum Model: string
     public function getKind(): string
     {
         return $this->getData()->kind;
+    }
+
+    /**
+     * Get palette IDs for this model
+     *
+     * @return array<string>
+     *
+     * @throws ProcessingException
+     */
+    public function getPaletteIds(): array
+    {
+        return $this->getData()->paletteIds;
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -12,6 +12,7 @@ enum Model: string
     case OG = 'og';
     case OG_PNG = 'og_png';
     case OG_BMP = 'og_bmp';
+    case V2 = 'v2';
     case AMAZON_KINDLE_2024 = 'amazon_kindle_2024';
     case AMAZON_KINDLE_PAPERWHITE_6TH_GEN = 'amazon_kindle_paperwhite_6th_gen';
     case AMAZON_KINDLE_PAPERWHITE_7TH_GEN = 'amazon_kindle_paperwhite_7th_gen';
@@ -25,6 +26,11 @@ enum Model: string
     case KOBO_AURA_HD = 'kobo_aura_hd';
     case INKY_IMPRESSION_13_3 = 'inky_impression_13_3';
     case M5_PAPER_S3 = 'm5_paper_s3';
+    case AMAZON_KINDLE_SCRIBE = 'amazon_kindle_scribe';
+    case SEEED_E1001 = 'seeed_e1001';
+    case SEEED_E1002 = 'seeed_e1002';
+    case WAVESHARE_4_26 = 'waveshare_4_26';
+    case WAVESHARE_7_5_BW = 'waveshare_7_5_bw';
 
     /**
      * Get the model data from JSON

--- a/src/Model.php
+++ b/src/Model.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Bnussbau\TrmnlPipeline;
+namespace Bnussbau\EpaperPipeline;
 
-use Bnussbau\TrmnlPipeline\Data\ModelData;
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Data\ModelData;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 
 enum Model: string
 {

--- a/src/Model.php
+++ b/src/Model.php
@@ -9,10 +9,11 @@ use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 
 enum Model: string
 {
-    case OG = 'og';
-    case OG_PNG = 'og_png';
-    case OG_BMP = 'og_bmp';
-    case V2 = 'v2';
+
+    case TRMNL_OG = 'trmnl_og';
+    case TRMNL_OG_2BIT = 'trmnl_og_2bit';
+    case TRMNL_X = 'trmnl_x';
+
     case AMAZON_KINDLE_2024 = 'amazon_kindle_2024';
     case AMAZON_KINDLE_PAPERWHITE_6TH_GEN = 'amazon_kindle_paperwhite_6th_gen';
     case AMAZON_KINDLE_PAPERWHITE_7TH_GEN = 'amazon_kindle_paperwhite_7th_gen';
@@ -21,7 +22,6 @@ enum Model: string
     case INKY_IMPRESSION_7_3 = 'inky_impression_7_3';
     case KOBO_LIBRA_2 = 'kobo_libra_2';
     case AMAZON_KINDLE_OASIS_2 = 'amazon_kindle_oasis_2';
-    case OG_PLUS = 'og_plus';
     case KOBO_AURA_ONE = 'kobo_aura_one';
     case KOBO_AURA_HD = 'kobo_aura_hd';
     case INKY_IMPRESSION_13_3 = 'inky_impression_13_3';
@@ -32,6 +32,12 @@ enum Model: string
     case WAVESHARE_4_26 = 'waveshare_4_26';
     case WAVESHARE_7_5_BW = 'waveshare_7_5_bw';
 
+    // TRMNL legacy models
+    case OG = 'og';
+    case OG_PNG = 'og_png';
+    case OG_BMP = 'og_bmp';
+    case V2 = 'v2';
+
     /**
      * Get the model data from JSON
      *
@@ -39,8 +45,14 @@ enum Model: string
      */
     public function getData(): ModelData
     {
-        // OG case should resolve to og_plus data
-        $modelName = $this === self::OG ? 'og_plus' : $this->value;
+        // resolve aliases
+        $modelName = match ($this) {
+            self::OG => 'og_png',
+            self::TRMNL_OG => 'og_png',
+            self::TRMNL_OG_2BIT => 'og_plus',
+            self::TRMNL_X => 'v2',
+            default => $this->value,
+        };
 
         return ModelData::getByName($modelName);
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -12,6 +12,7 @@ enum Model: string
     case TRMNL_OG = 'trmnl_og';
     case TRMNL_OG_2BIT = 'trmnl_og_2bit';
     case TRMNL_X = 'trmnl_x';
+    case TRMNL_OG_BWRY = 'trmnl_og_bwry';
 
     case AMAZON_KINDLE_2024 = 'amazon_kindle_2024';
     case AMAZON_KINDLE_PAPERWHITE_6TH_GEN = 'amazon_kindle_paperwhite_6th_gen';
@@ -30,11 +31,34 @@ enum Model: string
     case SEEED_E1002 = 'seeed_e1002';
     case WAVESHARE_4_26 = 'waveshare_4_26';
     case WAVESHARE_7_5_BW = 'waveshare_7_5_bw';
+    case GENERIC_16_9 = 'generic_16_9';
+    case PALMA = 'palma';
+    case ONYX_BOOX_GO_7 = 'onyx_boox_go_7';
+    case KOBO_GLO = 'kobo_glo';
+    case WAVESHARE_7_5_BWR = 'waveshare_7_5_bwr';
+    case WAVESHARE_7_5_BWRY = 'waveshare_7_5_bwry';
+    case ONXY_BOOX_NOVA_AIR_C = 'onxy_boox_nova_air_c';
+    case XTEINK_X4 = 'xteink_x4';
+    case NOOK_SIMPLE_TOUCH = 'nook_simple_touch';
+    case KOBO_SAGE = 'kobo_sage';
+    case AMAZON_KINDLE_VOYAGE = 'amazon_kindle_voyage';
+    case INKPLATE_5_2 = 'inkplate_5_2';
+    case RASPBERRY_PI_TOUCH_2 = 'raspberry_pi_touch_2';
+    case ED133UT2 = 'ed133ut2';
+    case AVALUE_EPD_42S = 'avalue_epd_42s';
+    case KOBO_TOUCH = 'kobo_touch';
+    case KOBO_FORMA = 'kobo_forma';
+    case OPENFRAME = 'openframe';
+    case AMAZON_KINDLE_PAPERWHITE_SIGNATURE_11TH_GEN = 'amazon_kindle_paperwhite_signature_11th_gen';
+    case INKPLATE_6_PLUS = 'inkplate_6_plus';
+    case KOBO_AURA_H2O_2 = 'kobo_aura_h2o_2';
 
     // TRMNL legacy models
     case OG = 'og';
     case OG_PNG = 'og_png';
     case OG_BMP = 'og_bmp';
+    case OG_PLUS = 'og_plus';
+    case OG_BWRY = 'og_bwry';
     case V2 = 'v2';
 
     /**
@@ -49,6 +73,7 @@ enum Model: string
             self::OG => 'og_png',
             self::TRMNL_OG => 'og_png',
             self::TRMNL_OG_2BIT => 'og_plus',
+            self::TRMNL_OG_BWRY => 'og_bwry',
             self::TRMNL_X => 'v2',
             default => $this->value,
         };

--- a/src/Model.php
+++ b/src/Model.php
@@ -9,7 +9,6 @@ use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 
 enum Model: string
 {
-
     case TRMNL_OG = 'trmnl_og';
     case TRMNL_OG_2BIT = 'trmnl_og_2bit';
     case TRMNL_X = 'trmnl_x';

--- a/src/StageInterface.php
+++ b/src/StageInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Bnussbau\TrmnlPipeline;
+namespace Bnussbau\EpaperPipeline;
 
 /**
  * Interface for pipeline stages

--- a/src/Stages/BrowserStage.php
+++ b/src/Stages/BrowserStage.php
@@ -33,6 +33,8 @@ class BrowserStage implements StageInterface
     /** @var array<string, mixed> */
     private array $browsershotOptions = [];
 
+    private ?string $timezone = null;
+
     public function __construct(private readonly ?Browsershot $browsershotInstance = null) {}
 
     /**
@@ -71,6 +73,18 @@ class BrowserStage implements StageInterface
     public function setBrowsershotOption(string $name, mixed $value): self
     {
         $this->browsershotOptions[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the timezone for the Browsershot environment.
+     *
+     * Example: 'UTC', 'America/New_York', 'Europe/Berlin'
+     */
+    public function timezone(string $timezone): self
+    {
+        $this->timezone = $timezone;
 
         return $this;
     }
@@ -147,6 +161,11 @@ class BrowserStage implements StageInterface
             $browsershot = $browsershot
                 ->windowSize($this->width ?? self::DEFAULT_WIDTH, $this->height ?? self::DEFAULT_HEIGHT)
                 ->setScreenshotType('png');
+
+            // Override timezone if explicitly provided
+            if ($this->timezone !== null) {
+                $browsershot = $browsershot->setEnvironmentOptions(['TZ' => $this->timezone]);
+            }
 
             // Apply custom options
             foreach ($this->browsershotOptions as $name => $value) {

--- a/src/Stages/BrowserStage.php
+++ b/src/Stages/BrowserStage.php
@@ -138,7 +138,7 @@ class BrowserStage implements StageInterface
             if ($this->browsershotInstance instanceof \Spatie\Browsershot\Browsershot) {
                 // Clone the provided instance and set HTML
                 $browsershot = clone $this->browsershotInstance;
-                $browsershot = $browsershot->html($this->html);
+                $browsershot = $browsershot->setHtml($this->html);
             } else {
                 // Create default Browsershot instance
                 $browsershot = Browsershot::html($this->html);

--- a/src/Stages/BrowserStage.php
+++ b/src/Stages/BrowserStage.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Bnussbau\EpaperPipeline\Stages;
 
+use Bnussbau\EpaperPipeline\EpaperPipeline;
 use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 use Bnussbau\EpaperPipeline\Model;
 use Bnussbau\EpaperPipeline\StageInterface;
-use Bnussbau\EpaperPipeline\EpaperPipeline;
 use Spatie\Browsershot\Browsershot;
 
 /**
@@ -169,14 +169,14 @@ class BrowserStage implements StageInterface
 
             // Configure Browsershot - URL or HTML, use provided instance or create default
             if ($hasUrl && $this->url !== null) {
-                if ($this->browsershotInstance instanceof \Spatie\Browsershot\Browsershot) {
+                if ($this->browsershotInstance instanceof Browsershot) {
                     $browsershot = (clone $this->browsershotInstance)->setUrl($this->url);
                 } else {
                     $browsershot = Browsershot::url($this->url);
                 }
             } else {
                 $html = $this->html ?? '';
-                if ($this->browsershotInstance instanceof \Spatie\Browsershot\Browsershot) {
+                if ($this->browsershotInstance instanceof Browsershot) {
                     $browsershot = (clone $this->browsershotInstance)->setHtml($html);
                 } else {
                     $browsershot = Browsershot::html($html);

--- a/src/Stages/BrowserStage.php
+++ b/src/Stages/BrowserStage.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Bnussbau\TrmnlPipeline\Stages;
+namespace Bnussbau\EpaperPipeline\Stages;
 
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\StageInterface;
-use Bnussbau\TrmnlPipeline\TrmnlPipeline;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\StageInterface;
+use Bnussbau\EpaperPipeline\EpaperPipeline;
 use Spatie\Browsershot\Browsershot;
 
 /**
@@ -159,7 +159,7 @@ class BrowserStage implements StageInterface
             throw new ProcessingException('No HTML content or URL provided for browser rendering. Use html() or url() method to set content or URL.');
         }
 
-        if (TrmnlPipeline::isFake()) {
+        if (EpaperPipeline::isFake()) {
             return $this->createMockImage();
         }
 

--- a/src/Stages/ImageStage.php
+++ b/src/Stages/ImageStage.php
@@ -533,7 +533,7 @@ class ImageStage implements StageInterface
         $imagick->setOption('dither', ($this->dither ?? true) ? 'FloydSteinberg' : 'None');
 
         // Use RGB colorspace for color palettes, GRAY for grayscale-only
-        $colorspace = $this->isColorPalette() ? Imagick::COLORSPACE_RGB : Imagick::COLORSPACE_GRAY;
+        $colorspace = $this->isColorPalette() ? Imagick::COLORSPACE_SRGB : Imagick::COLORSPACE_GRAY;
 
         // If colormap is set (from color palette), use the number of colors in the colormap
         // Otherwise use the colors property from model or default

--- a/src/Stages/ImageStage.php
+++ b/src/Stages/ImageStage.php
@@ -470,14 +470,17 @@ class ImageStage implements StageInterface
         $format = $this->format ?? self::DEFAULT_FORMAT;
         $bitDepth = $this->bitDepth ?? self::DEFAULT_BIT_DEPTH;
 
-        // Only apply colormap for PNG format with 2-bit depth
+        // Only apply colormap for PNG format with <= 2-bit depth
         // TODO: support other bit depths
-        if ($format !== 'png' || $bitDepth !== 2) {
+        if ($format !== 'png' || $bitDepth > 2) {
             return;
         }
 
-        // Use custom colormap if provided, otherwise use default 2-bit grayscale
-        $colors = $this->colormap ?? $this->getDefault2BitColormap();
+        // Determine colors: prefer explicit colormap, otherwise choose by bit depth
+        $colors = $this->colormap
+            ?? ($bitDepth == 2
+                ? $this->getDefault2BitColormap()
+                : ['#000000', '#ffffff']);
 
         // Apply colormap using native Imagick functions
         $this->setImageColormap($imagick, $colors);

--- a/src/Stages/ImageStage.php
+++ b/src/Stages/ImageStage.php
@@ -422,11 +422,12 @@ class ImageStage implements StageInterface
      */
     public function quantize(Imagick $imagick): void
     {
+        $imagick->setOption('dither', 'FloydSteinberg');
         $imagick->quantizeImage(
             $this->colors ?? self::DEFAULT_COLORS,
             Imagick::COLORSPACE_GRAY,
             0,
-            false,
+            true,
             false
         );
     }

--- a/src/Stages/ImageStage.php
+++ b/src/Stages/ImageStage.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Bnussbau\TrmnlPipeline\Stages;
+namespace Bnussbau\EpaperPipeline\Stages;
 
-use Bnussbau\TrmnlPipeline\Data\PaletteData;
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\StageInterface;
-use Bnussbau\TrmnlPipeline\TrmnlPipeline;
+use Bnussbau\EpaperPipeline\Data\PaletteData;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\StageInterface;
+use Bnussbau\EpaperPipeline\EpaperPipeline;
 use Imagick;
 use ImagickDraw;
 use ImagickDrawException;
@@ -278,7 +278,7 @@ class ImageStage implements StageInterface
             throw new ProcessingException('Invalid or missing image file: '.$imagePath);
         }
 
-        if (TrmnlPipeline::isFake()) {
+        if (EpaperPipeline::isFake()) {
             return $this->createMockProcessedImage($imagePath);
         }
 

--- a/src/Stages/ImageStage.php
+++ b/src/Stages/ImageStage.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Bnussbau\EpaperPipeline\Stages;
 
 use Bnussbau\EpaperPipeline\Data\PaletteData;
+use Bnussbau\EpaperPipeline\EpaperPipeline;
 use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 use Bnussbau\EpaperPipeline\Model;
 use Bnussbau\EpaperPipeline\StageInterface;
-use Bnussbau\EpaperPipeline\EpaperPipeline;
 use Imagick;
 use ImagickDraw;
 use ImagickDrawException;

--- a/src/Stages/ImageStage.php
+++ b/src/Stages/ImageStage.php
@@ -521,6 +521,13 @@ class ImageStage implements StageInterface
             return true;
         }
 
+        // Full-color / true-color devices (e.g. 24-bit) have no enumerated colormap,
+        // so palette->colors is null and no colormap is set. Their color count exceeds
+        // the 256-entry colormap range, so treat > 256 colors as full RGB.
+        if ($this->colors !== null && $this->colors > 256) {
+            return true;
+        }
+
         // Default to false (grayscale)
         return false;
     }

--- a/src/TrmnlPipeline.php
+++ b/src/TrmnlPipeline.php
@@ -16,6 +16,8 @@ class TrmnlPipeline
 
     private Pipeline $pipeline;
 
+    private static bool $isFake = false;
+
     public function __construct()
     {
         $this->pipeline = new Pipeline;
@@ -72,5 +74,29 @@ class TrmnlPipeline
                 $e
             );
         }
+    }
+
+    /**
+     * Enable fake mode for testing - prevents actual Browsershot and Imagick operations
+     */
+    public static function fake(): void
+    {
+        self::$isFake = true;
+    }
+
+    /**
+     * Disable fake mode
+     */
+    public static function restore(): void
+    {
+        self::$isFake = false;
+    }
+
+    /**
+     * Check if fake mode is enabled
+     */
+    public static function isFake(): bool
+    {
+        return self::$isFake;
     }
 }

--- a/tests/BrowserStageTest.php
+++ b/tests/BrowserStageTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\Stages\BrowserStage;
 use Spatie\Browsershot\Browsershot;
 
 describe('BrowserStage', function (): void {

--- a/tests/BrowserStageTest.php
+++ b/tests/BrowserStageTest.php
@@ -190,7 +190,7 @@ describe('BrowserStage', function (): void {
 
     it('can configure from model', function (): void {
         $stage = new BrowserStage;
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
 
         $result = $stage->configureFromModel($model);
 
@@ -199,7 +199,7 @@ describe('BrowserStage', function (): void {
 
     it('configures dimensions from model when not using default dimensions', function (): void {
         $stage = new BrowserStage;
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
 
         // Get model dimensions
         $modelWidth = $model->getWidth();
@@ -221,7 +221,7 @@ describe('BrowserStage', function (): void {
 
     it('ignores model dimensions when useDefaultDimensions is called', function (): void {
         $stage = new BrowserStage;
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
 
         // Set useDefaultDimensions first
         $stage->useDefaultDimensions();
@@ -243,7 +243,7 @@ describe('BrowserStage', function (): void {
 
     it('can process with model-configured dimensions', function (): void {
         $stage = new BrowserStage;
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
 
         $stage
             ->html('<html><body><h1>Test</h1></body></html>')
@@ -261,7 +261,7 @@ describe('BrowserStage', function (): void {
 
     it('can process with useDefaultDimensions ignoring model', function (): void {
         $stage = new BrowserStage;
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
 
         $stage
             ->html('<html><body><h1>Test</h1></body></html>')

--- a/tests/FakeTest.php
+++ b/tests/FakeTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use Bnussbau\TrmnlPipeline\Model;
+use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
+use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+use Bnussbau\TrmnlPipeline\TrmnlPipeline;
+
+afterEach(function (): void {
+    // Clean up after each test
+    TrmnlPipeline::restore();
+});
+
+it('can enable and disable fake mode', function (): void {
+    expect(TrmnlPipeline::isFake())->toBeFalse();
+
+    TrmnlPipeline::fake();
+    expect(TrmnlPipeline::isFake())->toBeTrue();
+
+    TrmnlPipeline::restore();
+    expect(TrmnlPipeline::isFake())->toBeFalse();
+});
+
+it('returns mock image path when browser stage is in fake mode', function (): void {
+    TrmnlPipeline::fake();
+
+    $browserStage = new BrowserStage;
+    $browserStage->html('<html><body>Test</body></html>');
+
+    $result = $browserStage(null);
+
+    expect($result)->toBeString();
+    expect(file_exists($result))->toBeTrue();
+    expect(str_contains($result, 'browsershot_fake_'))->toBeTrue();
+    expect(str_ends_with($result, '.png'))->toBeTrue();
+});
+
+it('returns mock processed image path when image stage is in fake mode', function (): void {
+    TrmnlPipeline::fake();
+
+    // Create a temporary input image
+    $inputImage = tempnam(sys_get_temp_dir(), 'test_input_').'.png';
+    $image = imagecreate(10, 10);
+    $white = imagecolorallocate($image, 255, 255, 255);
+    imagefill($image, 0, 0, $white);
+    imagepng($image, $inputImage);
+    imagedestroy($image);
+
+    $imageStage = new ImageStage;
+    $imageStage->format('png')->width(800)->height(480);
+
+    $result = $imageStage($inputImage);
+
+    expect($result)->toBeString();
+    expect(file_exists($result))->toBeTrue();
+    expect(str_contains($result, '_processed.png'))->toBeTrue();
+
+    // Clean up
+    unlink($inputImage);
+    unlink($result);
+});
+
+it('processes full pipeline in fake mode', function (): void {
+    TrmnlPipeline::fake();
+
+    $html = '<html><body>Test Content</body></html>';
+
+    $result = (new TrmnlPipeline)
+        ->model(Model::OG)
+        ->pipe((new BrowserStage)->html($html))
+        ->pipe(new ImageStage)
+        ->process();
+
+    expect($result)->toBeString();
+    expect(file_exists($result))->toBeTrue();
+    expect(str_contains((string) $result, '_processed.png'))->toBeTrue();
+
+    // Clean up
+    unlink($result);
+});
+
+it('respects image stage configuration in fake mode', function (): void {
+    TrmnlPipeline::fake();
+
+    // Create a temporary input image
+    $inputImage = tempnam(sys_get_temp_dir(), 'test_input_').'.png';
+    $image = imagecreate(10, 10);
+    $white = imagecolorallocate($image, 255, 255, 255);
+    imagefill($image, 0, 0, $white);
+    imagepng($image, $inputImage);
+    imagedestroy($image);
+
+    $imageStage = new ImageStage;
+    $imageStage
+        ->format('bmp')
+        ->width(400)
+        ->height(300)
+        ->outputPath('/tmp/custom_output.bmp');
+
+    $result = $imageStage($inputImage);
+
+    expect($result)->toBe('/tmp/custom_output.bmp');
+    expect(file_exists($result))->toBeTrue();
+
+    // Clean up
+    unlink($inputImage);
+    unlink($result);
+});
+
+it('still validates input in fake mode', function (): void {
+    TrmnlPipeline::fake();
+
+    $browserStage = new BrowserStage;
+
+    expect(fn (): string => $browserStage(null))
+        ->toThrow(Exception::class, 'No HTML content provided for browser rendering');
+});
+
+it('still validates file existence in fake mode', function (): void {
+    TrmnlPipeline::fake();
+
+    $imageStage = new ImageStage;
+
+    expect(fn (): string => $imageStage('/nonexistent/file.png'))
+        ->toThrow(Exception::class, 'Invalid or missing image file');
+});

--- a/tests/FakeTest.php
+++ b/tests/FakeTest.php
@@ -114,7 +114,7 @@ it('still validates input in fake mode', function (): void {
     $browserStage = new BrowserStage;
 
     expect(fn (): string => $browserStage(null))
-        ->toThrow(Exception::class, 'No HTML content provided for browser rendering');
+        ->toThrow(Exception::class, 'No HTML content or URL provided for browser rendering');
 });
 
 it('still validates file existence in fake mode', function (): void {

--- a/tests/FakeTest.php
+++ b/tests/FakeTest.php
@@ -2,28 +2,28 @@
 
 declare(strict_types=1);
 
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
-use Bnussbau\TrmnlPipeline\TrmnlPipeline;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\Stages\BrowserStage;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\EpaperPipeline;
 
 afterEach(function (): void {
     // Clean up after each test
-    TrmnlPipeline::restore();
+    EpaperPipeline::restore();
 });
 
 it('can enable and disable fake mode', function (): void {
-    expect(TrmnlPipeline::isFake())->toBeFalse();
+    expect(EpaperPipeline::isFake())->toBeFalse();
 
-    TrmnlPipeline::fake();
-    expect(TrmnlPipeline::isFake())->toBeTrue();
+    EpaperPipeline::fake();
+    expect(EpaperPipeline::isFake())->toBeTrue();
 
-    TrmnlPipeline::restore();
-    expect(TrmnlPipeline::isFake())->toBeFalse();
+    EpaperPipeline::restore();
+    expect(EpaperPipeline::isFake())->toBeFalse();
 });
 
 it('returns mock image path when browser stage is in fake mode', function (): void {
-    TrmnlPipeline::fake();
+    EpaperPipeline::fake();
 
     $browserStage = new BrowserStage;
     $browserStage->html('<html><body>Test</body></html>');
@@ -37,7 +37,7 @@ it('returns mock image path when browser stage is in fake mode', function (): vo
 });
 
 it('returns mock processed image path when image stage is in fake mode', function (): void {
-    TrmnlPipeline::fake();
+    EpaperPipeline::fake();
 
     // Create a temporary input image
     $inputImage = tempnam(sys_get_temp_dir(), 'test_input_').'.png';
@@ -62,11 +62,11 @@ it('returns mock processed image path when image stage is in fake mode', functio
 });
 
 it('processes full pipeline in fake mode', function (): void {
-    TrmnlPipeline::fake();
+    EpaperPipeline::fake();
 
     $html = '<html><body>Test Content</body></html>';
 
-    $result = (new TrmnlPipeline)
+    $result = (new EpaperPipeline)
         ->model(Model::OG)
         ->pipe((new BrowserStage)->html($html))
         ->pipe(new ImageStage)
@@ -81,7 +81,7 @@ it('processes full pipeline in fake mode', function (): void {
 });
 
 it('respects image stage configuration in fake mode', function (): void {
-    TrmnlPipeline::fake();
+    EpaperPipeline::fake();
 
     // Create a temporary input image
     $inputImage = tempnam(sys_get_temp_dir(), 'test_input_').'.png';
@@ -109,7 +109,7 @@ it('respects image stage configuration in fake mode', function (): void {
 });
 
 it('still validates input in fake mode', function (): void {
-    TrmnlPipeline::fake();
+    EpaperPipeline::fake();
 
     $browserStage = new BrowserStage;
 
@@ -118,7 +118,7 @@ it('still validates input in fake mode', function (): void {
 });
 
 it('still validates file existence in fake mode', function (): void {
-    TrmnlPipeline::fake();
+    EpaperPipeline::fake();
 
     $imageStage = new ImageStage;
 

--- a/tests/FakeTest.php
+++ b/tests/FakeTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
+use Bnussbau\EpaperPipeline\EpaperPipeline;
 use Bnussbau\EpaperPipeline\Model;
 use Bnussbau\EpaperPipeline\Stages\BrowserStage;
 use Bnussbau\EpaperPipeline\Stages\ImageStage;
-use Bnussbau\EpaperPipeline\EpaperPipeline;
 
 afterEach(function (): void {
     // Clean up after each test

--- a/tests/ImageStageTest.php
+++ b/tests/ImageStageTest.php
@@ -361,4 +361,99 @@ describe('ImageStage', function (): void {
             unlink($corruptedImagePath);
         }
     });
+
+    it('can set custom colormap', function (): void {
+        $stage = new ImageStage;
+        $customColormap = ['#FF0000', '#00FF00', '#0000FF', '#FFFF00'];
+
+        $result = $stage->colormap($customColormap);
+
+        expect($result)->toBe($stage);
+    });
+
+    it('applies default 2-bit grayscale colormap for PNG with 2-bit depth', function (): void {
+        $stage = new ImageStage;
+        $stage->format('png')->bitDepth(2);
+
+        $result = $stage($this->testImagePath);
+
+        expect($result)->toBeString();
+        expect(file_exists($result))->toBeTrue();
+
+        // Clean up
+        if (file_exists($result)) {
+            unlink($result);
+        }
+    });
+
+    it('applies custom colormap for PNG with 2-bit depth', function (): void {
+        $stage = new ImageStage;
+        $customColormap = ['#FF0000', '#00FF00', '#0000FF', '#FFFF00'];
+        $stage->format('png')->bitDepth(2)->colormap($customColormap);
+
+        $result = $stage($this->testImagePath);
+
+        expect($result)->toBeString();
+        expect(file_exists($result))->toBeTrue();
+
+        // Clean up
+        if (file_exists($result)) {
+            unlink($result);
+        }
+    });
+
+    it('does not apply colormap for non-PNG format', function (): void {
+        $stage = new ImageStage;
+        $stage->format('bmp')->bitDepth(2);
+
+        $result = $stage($this->testImagePath);
+
+        expect($result)->toBeString();
+        expect(file_exists($result))->toBeTrue();
+
+        // Clean up
+        if (file_exists($result)) {
+            unlink($result);
+        }
+    });
+
+    it('does not apply colormap for PNG with non-2-bit depth', function (): void {
+        $stage = new ImageStage;
+        $stage->format('png')->bitDepth(1);
+
+        $result = $stage($this->testImagePath);
+
+        expect($result)->toBeString();
+        expect(file_exists($result))->toBeTrue();
+
+        // Clean up
+        if (file_exists($result)) {
+            unlink($result);
+        }
+    });
+
+    it('applies colormap with colors from palettes.json format', function (): void {
+        $stage = new ImageStage;
+        // Colors from palettes.json color-7a palette
+        $paletteColors = [
+            '#000000',
+            '#FFFFFF',
+            '#FF0000',
+            '#00FF00',
+            '#0000FF',
+            '#FFFF00',
+            '#FFA500',
+        ];
+        $stage->format('png')->bitDepth(2)->colormap($paletteColors);
+
+        $result = $stage($this->testImagePath);
+
+        expect($result)->toBeString();
+        expect(file_exists($result))->toBeTrue();
+
+        // Clean up
+        if (file_exists($result)) {
+            unlink($result);
+        }
+    });
 });

--- a/tests/ImageStageTest.php
+++ b/tests/ImageStageTest.php
@@ -332,6 +332,32 @@ describe('ImageStage', function (): void {
         expect($stage->getFormat())->toBe('bmp');
     });
 
+    it('can enable and disable dithering', function (): void {
+        $stage = new ImageStage;
+
+        $resultEnable = $stage->dither(true);
+        expect($resultEnable)->toBe($stage);
+        expect($stage->getDither())->toBeTrue();
+
+        $resultDisable = $stage->dither(false);
+        expect($resultDisable)->toBe($stage);
+        expect($stage->getDither())->toBeFalse();
+    });
+
+    it('processes image with dithering disabled', function (): void {
+        $stage = new ImageStage;
+        $stage->width(50)->height(50)->dither(false);
+
+        $result = $stage($this->testImagePath);
+
+        expect($result)->toBeString();
+        expect(file_exists($result))->toBeTrue();
+
+        if (file_exists($result)) {
+            unlink($result);
+        }
+    });
+
     it('handles payload with zero string', function (): void {
         $stage = new ImageStage;
 

--- a/tests/ImageStageTest.php
+++ b/tests/ImageStageTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
 
 describe('ImageStage', function (): void {
     beforeEach(function (): void {

--- a/tests/ImageStageTest.php
+++ b/tests/ImageStageTest.php
@@ -80,7 +80,7 @@ describe('ImageStage', function (): void {
 
     it('can configure from model', function (): void {
         $stage = new ImageStage;
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
 
         $result = $stage->configureFromModel($model);
 
@@ -150,7 +150,7 @@ describe('ImageStage', function (): void {
 
     it('can process with model configuration', function (): void {
         $stage = new ImageStage;
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
         $stage->configureFromModel($model);
 
         $result = $stage($this->testImagePath);

--- a/tests/ModelDataTest.php
+++ b/tests/ModelDataTest.php
@@ -102,7 +102,7 @@ describe('ModelData', function (): void {
         $inkyImpression73 = ModelData::getByName('inky_impression_7_3');
         $inkyImpression133 = ModelData::getByName('inky_impression_13_3');
 
-        expect($inkyImpression73->paletteIds)->toBe(['color-7a', 'bw']);
+        expect($inkyImpression73->paletteIds)->toBe(['color-7a','color-6a','bw']);
         expect($inkyImpression133->paletteIds)->toBe(['color-6a', 'bw']);
     });
 

--- a/tests/ModelDataTest.php
+++ b/tests/ModelDataTest.php
@@ -102,7 +102,7 @@ describe('ModelData', function (): void {
         $inkyImpression73 = ModelData::getByName('inky_impression_7_3');
         $inkyImpression133 = ModelData::getByName('inky_impression_13_3');
 
-        expect($inkyImpression73->paletteIds)->toBe(['color-7a','color-6a','bw']);
+        expect($inkyImpression73->paletteIds)->toBe(['color-7a', 'color-6a', 'bw']);
         expect($inkyImpression133->paletteIds)->toBe(['color-6a', 'bw']);
     });
 

--- a/tests/ModelDataTest.php
+++ b/tests/ModelDataTest.php
@@ -88,7 +88,7 @@ describe('ModelData', function (): void {
         expect($model->height)->toBe(840);
         expect($model->colors)->toBe(256);
         expect($model->bitDepth)->toBe(8);
-        expect($model->scaleFactor)->toBe(2.414);
+        expect($model->scaleFactor)->toBe(1.75);
         expect($model->rotation)->toBe(90);
         expect($model->mimeType)->toBe('image/png');
         expect($model->offsetX)->toBe(75);

--- a/tests/ModelDataTest.php
+++ b/tests/ModelDataTest.php
@@ -75,6 +75,7 @@ describe('ModelData', function (): void {
         expect($model->offsetX)->toBe(0);
         expect($model->offsetY)->toBe(0);
         expect($model->kind)->toBe('trmnl');
+        expect($model->paletteIds)->toBe(['bw']);
     });
 
     it('has correct properties for Amazon Kindle 2024 model', function (): void {
@@ -94,6 +95,15 @@ describe('ModelData', function (): void {
         expect($model->offsetX)->toBe(75);
         expect($model->offsetY)->toBe(25);
         expect($model->kind)->toBe('kindle');
+        expect($model->paletteIds)->toBe(['gray-256']);
+    });
+
+    it('has correct palette IDs for models with color palettes', function (): void {
+        $inkyImpression73 = ModelData::getByName('inky_impression_7_3');
+        $inkyImpression133 = ModelData::getByName('inky_impression_13_3');
+
+        expect($inkyImpression73->paletteIds)->toBe(['color-7a', 'bw']);
+        expect($inkyImpression133->paletteIds)->toBe(['color-6a', 'bw']);
     });
 
 });

--- a/tests/ModelDataTest.php
+++ b/tests/ModelDataTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Bnussbau\TrmnlPipeline\Data\ModelData;
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Data\ModelData;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 
 describe('ModelData', function (): void {
     it('can load models from JSON', function (): void {

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Bnussbau\TrmnlPipeline\Data\ModelData;
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
-use Bnussbau\TrmnlPipeline\Model;
+use Bnussbau\EpaperPipeline\Data\ModelData;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Model;
 
 describe('Model', function (): void {
     it('can get model data for OG PNG', function (): void {
@@ -60,7 +60,7 @@ describe('Model', function (): void {
     });
 
     it('throws exception for invalid model name', function (): void {
-        expect(fn (): \Bnussbau\TrmnlPipeline\Data\ModelData => ModelData::getByName('invalid_model'))
+        expect(fn (): \Bnussbau\EpaperPipeline\Data\ModelData => ModelData::getByName('invalid_model'))
             ->toThrow(ProcessingException::class, "Model 'invalid_model' not found in models data");
     });
 });

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -60,7 +60,7 @@ describe('Model', function (): void {
     });
 
     it('throws exception for invalid model name', function (): void {
-        expect(fn (): \Bnussbau\EpaperPipeline\Data\ModelData => ModelData::getByName('invalid_model'))
+        expect(fn (): ModelData => ModelData::getByName('invalid_model'))
             ->toThrow(ProcessingException::class, "Model 'invalid_model' not found in models data");
     });
 });

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -8,7 +8,7 @@ use Bnussbau\EpaperPipeline\Model;
 
 describe('Model', function (): void {
     it('can get model data for OG PNG', function (): void {
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
         $data = $model->getData();
 
         expect($data->name)->toBe('og_png')
@@ -22,7 +22,7 @@ describe('Model', function (): void {
     });
 
     it('can get helper methods for model properties', function (): void {
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
 
         expect($model->getLabel())->toBe('TRMNL OG (1-bit)')
             ->and($model->getDescription())->toBe('TRMNL OG (1-bit)')

--- a/tests/PaletteDataTest.php
+++ b/tests/PaletteDataTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Bnussbau\TrmnlPipeline\Data\PaletteData;
+
+describe('PaletteData', function (): void {
+    it('can load palettes from JSON', function (): void {
+        $palettes = PaletteData::loadFromJson();
+
+        expect($palettes)->toBeArray();
+        expect($palettes)->toHaveKey('bw');
+        expect($palettes)->toHaveKey('color-6a');
+        expect($palettes)->toHaveKey('color-7a');
+        expect($palettes['bw'])->toBeInstanceOf(PaletteData::class);
+    });
+
+    it('can get palette by ID', function (): void {
+        $palette = PaletteData::getById('bw');
+
+        expect($palette)->toBeInstanceOf(PaletteData::class);
+        expect($palette->id)->toBe('bw');
+        expect($palette->name)->toBe('Black & White');
+        expect($palette->grays)->toBe(2);
+        expect($palette->colors)->toBeNull();
+    });
+
+    it('can get color palette by ID', function (): void {
+        $palette = PaletteData::getById('color-6a');
+
+        expect($palette)->toBeInstanceOf(PaletteData::class);
+        expect($palette->id)->toBe('color-6a');
+        expect($palette->name)->toBe('Color (6 colors)');
+        expect($palette->grays)->toBe(2);
+        expect($palette->colors)->toBe([
+            '#FF0000',
+            '#00FF00',
+            '#0000FF',
+            '#FFFF00',
+            '#000000',
+            '#FFFFFF',
+        ]);
+    });
+
+    it('can get all palette IDs', function (): void {
+        $ids = PaletteData::getAllIds();
+
+        expect($ids)->toBeArray();
+        expect($ids)->toContain('bw');
+        expect($ids)->toContain('gray-4');
+        expect($ids)->toContain('gray-16');
+        expect($ids)->toContain('gray-256');
+        expect($ids)->toContain('color-6a');
+        expect($ids)->toContain('color-7a');
+    });
+
+    it('throws exception for invalid palette ID', function (): void {
+        $palette = PaletteData::getById('invalid_palette');
+        expect($palette)->toBeNull();
+    });
+
+    it('has correct properties for color-7a palette', function (): void {
+        $palette = PaletteData::getById('color-7a');
+
+        expect($palette->id)->toBe('color-7a');
+        expect($palette->name)->toBe('Color (7 colors)');
+        expect($palette->grays)->toBe(2);
+        expect($palette->colors)->toBe([
+            '#000000',
+            '#FFFFFF',
+            '#FF0000',
+            '#00FF00',
+            '#0000FF',
+            '#FFFF00',
+            '#FFA500',
+        ]);
+        expect($palette->frameworkClass)->toBe('');
+    });
+});

--- a/tests/PaletteDataTest.php
+++ b/tests/PaletteDataTest.php
@@ -20,7 +20,7 @@ describe('PaletteData', function (): void {
 
         expect($palette)->toBeInstanceOf(PaletteData::class);
         expect($palette->id)->toBe('bw');
-        expect($palette->name)->toBe('Black & White');
+        expect($palette->name)->toBe('Black & White (1-bit)');
         expect($palette->grays)->toBe(2);
         expect($palette->colors)->toBeNull();
     });

--- a/tests/PaletteDataTest.php
+++ b/tests/PaletteDataTest.php
@@ -88,7 +88,7 @@ describe('PaletteData', function (): void {
     it('throws when palettes JSON file cannot be read', function (): void {
         $tmpFile = tempnam(sys_get_temp_dir(), 'palettes');
         if ($tmpFile === false) {
-            throw new \RuntimeException('Failed to create temp file');
+            throw new RuntimeException('Failed to create temp file');
         }
         chmod($tmpFile, 0000);
         try {
@@ -103,7 +103,7 @@ describe('PaletteData', function (): void {
     it('throws when palettes JSON is invalid', function (): void {
         $tmpFile = tempnam(sys_get_temp_dir(), 'palettes');
         if ($tmpFile === false) {
-            throw new \RuntimeException('Failed to create temp file');
+            throw new RuntimeException('Failed to create temp file');
         }
         try {
             file_put_contents($tmpFile, '{ invalid json }');
@@ -117,7 +117,7 @@ describe('PaletteData', function (): void {
     it('throws when palettes JSON does not decode to array', function (): void {
         $tmpFile = tempnam(sys_get_temp_dir(), 'palettes');
         if ($tmpFile === false) {
-            throw new \RuntimeException('Failed to create temp file');
+            throw new RuntimeException('Failed to create temp file');
         }
         try {
             file_put_contents($tmpFile, '123');
@@ -131,7 +131,7 @@ describe('PaletteData', function (): void {
     it('throws when palettes JSON is missing data array', function (): void {
         $tmpFile = tempnam(sys_get_temp_dir(), 'palettes');
         if ($tmpFile === false) {
-            throw new \RuntimeException('Failed to create temp file');
+            throw new RuntimeException('Failed to create temp file');
         }
         try {
             file_put_contents($tmpFile, '{}');
@@ -145,7 +145,7 @@ describe('PaletteData', function (): void {
     it('throws when palette entry is missing id field', function (): void {
         $tmpFile = tempnam(sys_get_temp_dir(), 'palettes');
         if ($tmpFile === false) {
-            throw new \RuntimeException('Failed to create temp file');
+            throw new RuntimeException('Failed to create temp file');
         }
         try {
             file_put_contents($tmpFile, '{"data":[{"name":"no-id"}]}');

--- a/tests/PaletteDataTest.php
+++ b/tests/PaletteDataTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Bnussbau\TrmnlPipeline\Data\PaletteData;
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Data\PaletteData;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 
 describe('PaletteData', function (): void {
     it('can load palettes from JSON', function (): void {

--- a/tests/PaletteDataTest.php
+++ b/tests/PaletteDataTest.php
@@ -75,7 +75,7 @@ describe('PaletteData', function (): void {
             '#FFFF00',
             '#FFA500',
         ]);
-        expect($palette->frameworkClass)->toBe('');
+        expect($palette->frameworkClass)->toBe('screen--color-7a');
     });
 
     it('throws when palettes JSON file does not exist', function (): void {

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -191,4 +191,40 @@ describe('Pipeline', function (): void {
             unlink($result);
         }
     });
+
+    it('processes color palette end-to-end with seed_e1002 model', function (): void {
+        $pipeline = new TrmnlPipeline;
+        $model = Model::SEEED_E1002; // Has color-spectra6 palette
+
+        // Verify model has color palette
+        expect($model->getPaletteIds())->toContain('color-spectra6');
+
+        // Load HTML file with color palette colors
+        $htmlPath = __DIR__ . '/assets/color_spectra6_test.html';
+        expect(file_exists($htmlPath))->toBeTrue();
+        $htmlContent = file_get_contents($htmlPath);
+        expect($htmlContent)->toBeString();
+
+        // Create pipeline with BrowserStage and ImageStage
+        $browserStage = new BrowserStage;
+        $browserStage->html($htmlContent);
+
+        $imageStage = new ImageStage;
+
+        // Process through pipeline
+        $pipeline
+            ->model($model)
+            ->pipe($browserStage)
+            ->pipe($imageStage);
+
+        $result = $pipeline->process();
+
+        expect($result)->toBeString();
+        expect(file_exists($result))->toBeTrue();
+        
+        // Clean up
+        if (file_exists($result)) {
+            unlink($result);
+        }
+    });
 });

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -200,7 +200,7 @@ describe('Pipeline', function (): void {
         expect($model->getPaletteIds())->toContain('color-spectra6');
 
         // Load HTML file with color palette colors
-        $htmlPath = __DIR__ . '/assets/color_spectra6_test.html';
+        $htmlPath = __DIR__.'/assets/color_spectra6_test.html';
         expect(file_exists($htmlPath))->toBeTrue();
         $htmlContent = file_get_contents($htmlPath);
         expect($htmlContent)->toBeString();
@@ -221,7 +221,7 @@ describe('Pipeline', function (): void {
 
         expect($result)->toBeString();
         expect(file_exists($result))->toBeTrue();
-        
+
         // Clean up
         if (file_exists($result)) {
             unlink($result);

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-use Bnussbau\TrmnlPipeline\Exceptions\ProcessingException;
-use Bnussbau\TrmnlPipeline\Model;
-use Bnussbau\TrmnlPipeline\StageInterface;
-use Bnussbau\TrmnlPipeline\Stages\BrowserStage;
-use Bnussbau\TrmnlPipeline\Stages\ImageStage;
-use Bnussbau\TrmnlPipeline\TrmnlPipeline;
+use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
+use Bnussbau\EpaperPipeline\Model;
+use Bnussbau\EpaperPipeline\StageInterface;
+use Bnussbau\EpaperPipeline\Stages\BrowserStage;
+use Bnussbau\EpaperPipeline\Stages\ImageStage;
+use Bnussbau\EpaperPipeline\EpaperPipeline;
 
 describe('Pipeline', function (): void {
     it('can be instantiated', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
 
-        expect($pipeline)->toBeInstanceOf(TrmnlPipeline::class);
+        expect($pipeline)->toBeInstanceOf(EpaperPipeline::class);
         expect($pipeline->getModel())->toBeNull();
     });
 
     it('can set and get model', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
         $model = Model::OG_PNG;
 
         $pipeline->model($model);
@@ -27,7 +27,7 @@ describe('Pipeline', function (): void {
     });
 
     it('can chain model setting', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
         $model = Model::OG_PNG;
 
         $result = $pipeline->model($model);
@@ -36,7 +36,7 @@ describe('Pipeline', function (): void {
     });
 
     it('can add stages to pipeline', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
         $stage = new class implements StageInterface
         {
             public function __invoke(mixed $payload): mixed
@@ -51,7 +51,7 @@ describe('Pipeline', function (): void {
     });
 
     it('can process payload through pipeline', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
         $stage = new class implements StageInterface
         {
             public function __invoke(mixed $payload): mixed
@@ -68,7 +68,7 @@ describe('Pipeline', function (): void {
     });
 
     it('can process payload through multiple stages', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
 
         $stage1 = new class implements StageInterface
         {
@@ -94,7 +94,7 @@ describe('Pipeline', function (): void {
     });
 
     it('throws ProcessingException when stage fails', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
         $stage = new class implements StageInterface
         {
             public function __invoke(mixed $payload): mixed
@@ -110,7 +110,7 @@ describe('Pipeline', function (): void {
     });
 
     it('can chain pipe calls', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
         $stage1 = new class implements StageInterface
         {
             public function __invoke(mixed $payload): mixed
@@ -132,7 +132,7 @@ describe('Pipeline', function (): void {
     });
 
     it('automatically configures stages with model when model is set', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
         $model = Model::OG_BMP;
         $imageStage = new ImageStage;
 
@@ -145,7 +145,7 @@ describe('Pipeline', function (): void {
     });
 
     it('does not configure stages when no model is set', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
         $imageStage = new ImageStage;
 
         // Add stage without setting model
@@ -156,7 +156,7 @@ describe('Pipeline', function (): void {
     });
 
     it('processes color palette end-to-end with inky_impression_13_3 model', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
         $model = Model::INKY_IMPRESSION_13_3; // Has color-6a palette
 
         // Verify model has color palette
@@ -193,7 +193,7 @@ describe('Pipeline', function (): void {
     });
 
     it('processes color palette end-to-end with seed_e1002 model', function (): void {
-        $pipeline = new TrmnlPipeline;
+        $pipeline = new EpaperPipeline;
         $model = Model::SEEED_E1002; // Has color-spectra6 palette
 
         // Verify model has color palette

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
+use Bnussbau\EpaperPipeline\EpaperPipeline;
 use Bnussbau\EpaperPipeline\Exceptions\ProcessingException;
 use Bnussbau\EpaperPipeline\Model;
 use Bnussbau\EpaperPipeline\StageInterface;
 use Bnussbau\EpaperPipeline\Stages\BrowserStage;
 use Bnussbau\EpaperPipeline\Stages\ImageStage;
-use Bnussbau\EpaperPipeline\EpaperPipeline;
 
 describe('Pipeline', function (): void {
     it('can be instantiated', function (): void {
@@ -99,7 +99,7 @@ describe('Pipeline', function (): void {
         {
             public function __invoke(mixed $payload): mixed
             {
-                throw new \Exception('Stage failed');
+                throw new Exception('Stage failed');
             }
         };
 

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -197,7 +197,7 @@ describe('Pipeline', function (): void {
         $model = Model::SEEED_E1002; // Has color-spectra6 palette
 
         // Verify model has color palette
-        expect($model->getPaletteIds())->toContain('color-spectra6');
+        expect($model->getPaletteIds())->toContain('color-6a');
 
         // Load HTML file with color palette colors
         $htmlPath = __DIR__.'/assets/color_spectra6_test.html';

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -19,7 +19,7 @@ describe('Pipeline', function (): void {
 
     it('can set and get model', function (): void {
         $pipeline = new EpaperPipeline;
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
 
         $pipeline->model($model);
 
@@ -28,7 +28,7 @@ describe('Pipeline', function (): void {
 
     it('can chain model setting', function (): void {
         $pipeline = new EpaperPipeline;
-        $model = Model::OG_PNG;
+        $model = Model::TRMNL_OG;
 
         $result = $pipeline->model($model);
 

--- a/tests/assets/color_6a_test.html
+++ b/tests/assets/color_6a_test.html
@@ -1,0 +1,22 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>Color 6a Test</title>
+    <style>
+        body { margin: 0; font-family: sans-serif; }
+        .row { display: flex; width: 100%; height: 80vh; }
+        .block { flex: 1 1 0; display:flex; align-items:center; justify-content:center; color:#fff; font-weight:700; }
+        .block.small { height: 20vh; }
+    </style>
+</head>
+<body>
+    <div class="row">
+        <div class="block" style="background:#FF0000">#FF0000</div>
+        <div class="block" style="background:#00FF00;color:#000">#00FF00</div>
+        <div class="block" style="background:#0000FF">#0000FF</div>
+        <div class="block" style="background:#FFFF00;color:#000">#FFFF00</div>
+        <div class="block" style="background:#000000">#000000</div>
+        <div class="block" style="background:#FFFFFF;color:#000">#FFFFFF</div>
+    </div>
+</body>
+</html>

--- a/tests/assets/color_spectra6_test.html
+++ b/tests/assets/color_spectra6_test.html
@@ -1,0 +1,22 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>Color 6a Test</title>
+    <style>
+        body { margin: 0; font-family: sans-serif; }
+        .row { display: flex; width: 100%; height: 80vh; }
+        .block { flex: 1 1 0; display:flex; align-items:center; justify-content:center; color:#fff; font-weight:700; }
+        .block.small { height: 20vh; }
+    </style>
+</head>
+<body>
+    <div class="row">
+        <div class="block" style="background:#52180A">#52180A</div>
+        <div class="block" style="background:#59683F">#59683F</div>
+        <div class="block" style="background:#28487B">#28487B</div>
+        <div class="block" style="background:#968327">#968327</div>
+        <div class="block" style="background:#000000">#000000</div>
+        <div class="block" style="background:#FFFFFF;color:#000">#FFFFFF</div>
+    </div>
+</body>
+</html>

--- a/tests/assets/framework2_og.html
+++ b/tests/assets/framework2_og.html
@@ -3,8 +3,8 @@
     <meta charset="utf-8"/>
     <link rel="preconnect" href="https://fonts.bunny.net"/>
     <link href="https://fonts.bunny.net/css?family=Inter:300,400,500" rel="stylesheet"/>
-    <link rel="stylesheet" href="https://usetrmnl.com/css/2.0.0/plugins.css"/>
-    <script src="https://usetrmnl.com/js/2.0.0/plugins.js"></script>
+    <link rel="stylesheet" href="https://trmnl.com/css/2.1.0/plugins.css"/>
+    <script src="https://trmnl.com/js/2.1.0/plugins.js"></script>
     <title>TrmnlServer</title></head>
 <body class="environment trmnl">
 <div class="screen screen--ogv2 screen--2bit">

--- a/tests/assets/framework2_og.html
+++ b/tests/assets/framework2_og.html
@@ -12,7 +12,7 @@
         <div class="layout">
             <div class="flex flex--col gap gap--large">
                 <span class="title">TRMNL OG 2-bit</span>
-                <span class="label">“This screen was rendered and processed by bnussbau/trmnl-pipeline-php”</span>
+                <span class="label">“This screen was rendered and processed by bnussbau/epaper-pipeline-php”</span>
                 <span class="label label--underline">PNG 800x480 8-bit Grayscale Gray 4c</span>
             </div>
         </div>

--- a/tests/assets/framework2_og_bmp.html
+++ b/tests/assets/framework2_og_bmp.html
@@ -3,8 +3,8 @@
     <meta charset="utf-8"/>
     <link rel="preconnect" href="https://fonts.bunny.net"/>
     <link href="https://fonts.bunny.net/css?family=Inter:300,400,500" rel="stylesheet"/>
-    <link rel="stylesheet" href="https://usetrmnl.com/css/2.0.0/plugins.css"/>
-    <script src="https://usetrmnl.com/js/2.0.0/plugins.js"></script>
+    <link rel="stylesheet" href="https://trmnl.com/css/2.1.0/plugins.css"/>
+    <script src="https://trmnl.com/js/2.1.0/plugins.js"></script>
     <title>TrmnlServer</title></head>
 <body class="environment trmnl">
 <div class="screen screen--og screen--1bit">


### PR DESCRIPTION
Hi! 
When using a regular, non-e-paper tablet as a larapaper display, images rendered grayscale even if number of color palette set to 24bit. 

`isColorPalette()` only returns true for palette-based devices: either a `paletteId` whose `PaletteData` has a non-null `colors` array, or an explicit `colormap`. Full-color devices have no enumerated colormap, so `configureColormapFromPalette()` leaves both `paletteId` and `colormap` null. They therefore fell through to the default `false` branch, so `Imagick::COLORSPACE_GRAY` used to render grayscale

Use the integer `colors` count as the signal for these devices: a count above the 256-entry colormap range means full RGB. A 24-bit device reports `colors = 16777216`, so `colors > 256` selects `COLORSPACE_SRGB` and color is preserved. Palette-based devices (<= 256 colors) are unaffected and still take the colormap path.

Kind regards,
negenii